### PR TITLE
Added from name for mail api call

### DIFF
--- a/SendGrid/Mail.php
+++ b/SendGrid/Mail.php
@@ -7,6 +7,7 @@ class Mail
   
   private $to_list, 
           $from,
+          $from_name,
           $cc_list,
           $bcc_list,
           $subject,
@@ -136,6 +137,28 @@ class Mail
   {
     $this->from = $email;
     return $this;
+  }
+  
+  /**
+   * setFromName
+   * set the from name
+   * @param String $name - a name
+   * @return the SendGrid\Mail object.
+   */
+  public function setFromName($name)
+  {
+    $this->from_name = $name;
+    return $this;
+  }
+  
+  /**
+   * getFromName
+   * get the from name
+   * @return the from name
+   */
+  public function getFromName()
+  {
+    return $this->from_name;
   }
   
   /**

--- a/SendGrid/Web.php
+++ b/SendGrid/Web.php
@@ -38,6 +38,7 @@ class Web extends Api implements MailInterface
       'html'      => $mail->getHtml(),
       'text'      => $mail->getText(),
       'from'      => $mail->getFrom(),
+      'fromname'  => $mail->getFromName(),
       'to'        => $mail->getFrom(),
       'x-smtpapi' => $mail->getHeadersJson()
     );

--- a/Test/SendGrid/MailTest.php
+++ b/Test/SendGrid/MailTest.php
@@ -62,6 +62,15 @@ class MailTest extends PHPUnit_Framework_TestCase
     $this->assertEquals("foo@bar.com", $message->getFrom());
   }
 
+  public function testFromNameAccessors()
+  {
+    $message = new SendGrid\Mail();
+
+    $message->setFromName("foo");
+
+    $this->assertEquals("foo", $message->getFromName());
+  }
+
   public function testCcAccessors()
   {
     $message = new SendGrid\Mail();

--- a/Test/SendGrid/WebTest.php
+++ b/Test/SendGrid/WebTest.php
@@ -18,6 +18,7 @@ class WebTest extends PHPUnit_Framework_TestCase
 
     $message->
       setFrom('bar@foo.com')->
+      setFromName('foo')->
       setSubject('foobar subject')->
       setText('foobar text')->
       addTo('foo@bar.com')->
@@ -34,6 +35,7 @@ class WebTest extends PHPUnit_Framework_TestCase
       'html' => null,
       'text' => 'foobar text',
       'from' => 'bar@foo.com',
+      'fromname' => 'foo',
       'to' => 'bar@foo.com',
       'x-smtpapi' => '{"to":["foo@bar.com"]}',
       'files[mynewattachment.jpg]' => '@mynewattachment.jpg'


### PR DESCRIPTION
I wasn't sure how to do toname and replyto because of the way the it opts to not use the to and uses headers if it has an attached file, hopefully someone else can add those.
