### PR TITLE
Add composer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,9 @@
+{
+    "name": "sendgrid/sendgrid-php",
+    "description": "This library allows you to quickly and easily send emails through SendGrid using PHP.",
+    "homepage": "http://sendgrid.com",
+    "license": "MIT",
+    "autoload": {
+        "files": ["SendGrid_loader.php"]
+    }
+}


### PR DESCRIPTION
[Composer](http://getcomposer.org/) is a dependency manager for PHP similar to bundler for Ruby and others. It makes library installation and management easier, and more importantly encourages code re-use within the PHP world, something PHP currently does VERY poorly.

So, in theory, all one needs to do to add composer support is to add `composer.json`. I started out this way, but had to make severe changes because of the embedded SwiftMailer dependency. So there are several changes for this simple task, but I think this is a much better way to do it. All tests still pass.
- Removed embedded SwiftMailer library
- Set up composer to install SwiftMailer as a dependency (same minor version)
- Modify class loading to use composer autoloader in lib and in tests
- Update README with new installation, usage
