### PR TITLE
Add curl Timeout and Connection Timeout for send function.

### DIFF
--- a/SendGrid/Web.php
+++ b/SendGrid/Web.php
@@ -131,6 +131,9 @@ class Web extends Api implements MailInterface
     curl_setopt($session, CURLOPT_HEADER, false);
     curl_setopt($session, CURLOPT_RETURNTRANSFER, true);
      
+    curl_setopt($session, CURLOPT_CONNECTTIMEOUT, 5);
+    curl_setopt($session, CURLOPT_TIMEOUT, 30);
+
     // obtain response
     $response = curl_exec($session);
     curl_close($session);


### PR DESCRIPTION
Add a connection timeout, so if the connection to the server fails or hangs a failed response can be returned to the PHP script. This stops the PHP from timing out waiting for a failed connection or response.
