### PR TITLE
Allow setting the hostname, in case you are using a local relay.

### DIFF
--- a/SendGrid/Smtp.php
+++ b/SendGrid/Smtp.php
@@ -13,6 +13,8 @@ class Smtp extends Api implements MailInterface
   private $swift_instances = array();
   protected $port;
 
+  private $hostname = 'smtp.sendgrid.net';
+
   public function __construct($username, $password)
   {
     /* check for SwiftMailer,
@@ -40,6 +42,13 @@ class Smtp extends Api implements MailInterface
     return $this;
   }
 
+  public function setHostname($hostname)
+  {
+    $this->hostname = $hostname;
+
+    return $this;
+  }
+
   /* _getSwiftInstance
    * initialize and return the swift transport instance
    * @return the Swift_Mailer instance
@@ -48,7 +57,7 @@ class Smtp extends Api implements MailInterface
   {
     if (!isset($this->swift_instances[$port]))
     {
-      $transport = \Swift_SmtpTransport::newInstance('smtp.sendgrid.net', $port);
+      $transport = \Swift_SmtpTransport::newInstance($this->hostname, $port);
       $transport->setUsername($this->username);
       $transport->setPassword($this->password);
 


### PR DESCRIPTION
We are using a local relay, as documented in http://sendgrid.com/docs/Integrate/#--Power-Users-and-High-Volume-Senders

This allows us to have great delivery performance, while still offering us all the magic tricks the Sendgrid SMTP API. Using the client library, we were unable to use our local relay because the hostname is hardcoded.

I've made the hostname configurable using a method 'setHostname()'. It defaults to the existing value (smtp.sendgrid.net), so this change be fully backwards compatible.
