### PR TITLE
Fix swiftmailer dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
       "files": ["SendGrid_loader.php"]
     },
     "require": {
-      "swiftmailer/swiftmailer": "v5.0.1"
+      "swiftmailer/swiftmailer": "~5.0.1"
     },
     "require-dev": {
       "phpunit/phpunit": "3.7.*"

--- a/composer.lock
+++ b/composer.lock
@@ -3,20 +3,20 @@
         "This file locks the dependencies of your project to a known state",
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
     ],
-    "hash": "0ae51c9302e75831f1f3ebdc1018b9a8",
+    "hash": "ea22e870f1bff93527381a014349e329",
     "packages": [
         {
             "name": "swiftmailer/swiftmailer",
-            "version": "v5.0.1",
+            "version": "v5.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/swiftmailer/swiftmailer.git",
-                "reference": "619aceb969f1e8759edc28fb22f9b64b3bddbc1e"
+                "reference": "f3917ecef35a4e4d98b303eb9fee463bc983f379"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/619aceb969f1e8759edc28fb22f9b64b3bddbc1e",
-                "reference": "619aceb969f1e8759edc28fb22f9b64b3bddbc1e",
+                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/f3917ecef35a4e4d98b303eb9fee463bc983f379",
+                "reference": "f3917ecef35a4e4d98b303eb9fee463bc983f379",
                 "shasum": ""
             },
             "require": {
@@ -52,7 +52,7 @@
                 "mail",
                 "mailer"
             ],
-            "time": "2013-06-17 13:32:32"
+            "time": "2013-08-30 12:35:21"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
Remove the "strict" version for swiftmailer dependency.

Example:
- my project use swiftmailer 5.0.2
- i want to use sendgrid (which strictly needs 5.0.1)
- i run into conflicts — i have to downgrade explicitly to 5.0.1

Instead, set your minimal requirement for your vendor. `~5.0.1` means _"I need at least 5.0.1 version, and I'm ok with minor upgrades"_.

Btw, versioning composer.lock for a library is useless.
