### PR TITLE
Added check for the existence of extension

### DIFF
--- a/SendGrid/Web.php
+++ b/SendGrid/Web.php
@@ -69,12 +69,12 @@ class Web extends Api implements MailInterface
       if (function_exists("curl_file_create")) {
         foreach($mail->getAttachments() as $attachment)
       	{
-      	    $params['files['.$attachment['filename'].'.'.$attachment['extension'].']'] = new \CURLFile($attachment['file']);
+      	    $params['files['.$attachment['filename'].(isset($attachment['extension'])?'.'.$attachment['extension']:'').']'] = new \CURLFile($attachment['file']);
       	}
       }else{
         foreach($mail->getAttachments() as $attachment)
         {
-      	    $params['files['.$attachment['filename'].'.'.$attachment['extension'].']'] = '@'.$attachment['file'];
+      	    $params['files['.$attachment['filename'].(isset($attachment['extension'])?'.'.$attachment['extension']:'').']'] = '@'.$attachment['file'];
         }
       }
     }


### PR DESCRIPTION
If I try to attached a file without an extension, I get an error saying that the key 'extension' is not in exist, and this is understandable, since the key is not created when the extension is not exist.

Additional info:
http://www.php.net/manual/en/function.pathinfo.php
"If the path does not have an extension, no extension element will be returned (see second example below)."
