### PR TITLE
Fix issue with curl not properly returning when an error occurs

### DIFF
--- a/SendGrid/Web.php
+++ b/SendGrid/Web.php
@@ -138,12 +138,19 @@ class Web extends Api implements MailInterface
 
     // obtain response
     $response = curl_exec($session);
+    
+    $curlError = false;
     if($response === false)
     {
-        return curl_error($session);
+        $curlError = curl_error($session);
     }
+
     curl_close($session);
 
+    if($curlError !== false)
+    {
+        return $curlError;
+    }
     return $response;
   }
 }


### PR DESCRIPTION
Issue https://github.com/sendgrid/sendgrid-php/issues/48

Must grab the error before closing curl, then return it after closing curl if applicable.
