### PR TITLE
Update Smtp.php

### DIFF
--- a/lib/SendGrid/Smtp.php
+++ b/lib/SendGrid/Smtp.php
@@ -171,16 +171,8 @@ class Smtp extends Api implements EmailInterface
   {
     $swift = $this->_getSwiftInstance($this->port);
     $message = $this->_mapToSwift($email);
-
-    try 
-    {
-      $swift->send($message, $failures);
-    }
-    catch(\Swift_TransportException $e)
-    {
-      throw new AuthException('Bad username / password');
-    }
-
+    $swift->send($message, $failures);
+    
     return true;
   }
 }


### PR DESCRIPTION
This updates stops sendgrid from intercepting potentionally useful Swiftmail error messages.

If the $swift->send function triggers a Swift_TransportException, it will not necessarily be due to username/password errors. Swiftmailer will raise this exception for a lot of different reasons, username/password being only one of them.

Catching the error message and replacing it with new AuthException('Bad username / password') is not the right thing to do, because you cannot know if this was the reason the exception was thrown.

It is probably better to let the swiftmailer exception be thrown as is and not catch it.
