### PR TITLE
Smtp send fix

### DIFF
--- a/lib/SendGrid/Smtp.php
+++ b/lib/SendGrid/Smtp.php
@@ -82,7 +82,7 @@ class Smtp extends Api implements EmailInterface
     /*
      * Since we're sending transactional email, we want the message to go to one person at a time, rather
      * than a bulk send on one message. In order to do this, we'll have to send the list of recipients through the headers
-     * but Swift still requires a 'to' address. So we'll falsify it with the from address, as it will be 
+     * but Swift still requires a 'to' address. So we'll falsify it with the from address, as it will be
      * ignored anyway.
      */
     $message->setTo($email->getFrom());


### PR DESCRIPTION
This commit fixes `Expected response code 250 but got code "421", with message "421 Timeout waiting for data from client"` raised by SwiftMailer.

Idea from http://www.prowebdev.us/2013/06/swiftmailersymfony2-expected-response.html
