### PR TITLE
Email.php: smtpapi method is addFilter and not addFilterSetting

### DIFF
--- a/lib/SendGrid/Email.php
+++ b/lib/SendGrid/Email.php
@@ -274,7 +274,7 @@ class Email {
   }
   
   public function addFilterSetting($filter_name, $parameter_name, $parameter_value) {
-    $this->smtpapi->addFilterSetting($filter_name, $parameter_name, $parameter_value);
+    $this->smtpapi->addFilter($filter_name, $parameter_name, $parameter_value);
     return $this;
   }
 


### PR DESCRIPTION
After looking at the smtpapi source, i see that this method does not exist...
