### PR TITLE
Specify Unirest version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["SendGrid", "sendgrid", "email", "send", "grid"],
   "require": {
     "php": ">=5.3",
-    "mashape/unirest-php": "dev-master",
+    "mashape/unirest-php": "1.2",
     "sendgrid/smtpapi": "0.0.1"
   },
   "require-dev": {


### PR DESCRIPTION
With the current Sendgrid package, installation fails with the following message without minimum stability set to `dev`:

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - sendgrid/sendgrid 2.0.4 requires mashape/unirest-php dev-master -> no matching package found.
    - Installation request for sendgrid/sendgrid 2.0.4 -> satisfiable by sendgrid/sendgrid[2.0.4].

Potential causes:
 - A typo in the package name
 - The package is not available in a stable-enough version according to your minimum-stability setting
   see <https://groups.google.com/d/topic/composer-dev/_g3ASeIFlrc/discussion> for more details.

Read <http://getcomposer.org/doc/articles/troubleshooting.md> for further common problems.      
```

I've specified the most recent of two _releases_ for Unirest with this PR.
