### PR TITLE
Do not call autoloader when checking if CurlFile class exists

### DIFF
--- a/lib/SendGrid/Email.php
+++ b/lib/SendGrid/Email.php
@@ -353,7 +353,7 @@ class Email {
         }
 
         $contents   = '@' . $file; 
-        if (class_exists('CurlFile')) { // php >= 5.5
+        if (class_exists('CurlFile', false)) { // php >= 5.5
           $contents = new \CurlFile($file, $extension, $filename);
         }
 


### PR DESCRIPTION
As CurlFile is a built-in class there is no reason to invoke the autoloader, doing so can cause issues for users who define their own autoloader by creating an "__autoload" function or by registering an autoloader with "spl_autoload_register".

I tested this change on Php 5.5 (CurlFile present) and Php 5.3 (CurlFile not present)
