### PR TITLE
updated library to allow for passing in url

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,43 @@ $email->addTo('foo@bar.com')->
        addHeader('X-Transport', 'web');
 ```
 
+### Options
+Options may be passed to the library when initializing the SendGrid object:
+
+```php
+$options = array(
+  'turn_off_ssl_verification' => false,
+  'protocol' => 'https',
+  'host' => 'api.sendgrid.com',
+  'endpoint' => '/api/mail.send.json',
+  'port' => null,
+  'url' => null
+);
+$sendgrid = new SendGrid('username', 'password', $options);
+```
+
+#### Changing URL
+You may change the URL sendgrid-php uses to send email by supplying various parameters to `options`, all parameters are optional:
+
+```php
+$sendgrid = new SendGrid('username', 'password', array( 'protocol' => 'http', 'host' => 'sendgrid.org', 'endpoint' => '/send', 'port' => '80' ));
+```
+
+A full URL may also be provided:
+
+```php
+$sendgrid = new SendGrid('username', 'password', array( 'url' => 'http://sendgrid.org:80/send'));
+```
+
+#### Ignoring SSL certificate verification
+
+You can optionally ignore verification of SSL certificate when using the Web API.
+
+```php
+$sendgrid   = new SendGrid(SENDGRID_USERNAME, SENDGRID_PASSWORD,  array("turn_off_ssl_verification" => true));
+```
+
+
 ### Sending to 1,000s of emails in one batch
 
 Sometimes you might want to send 1,000s of emails in one request. You can do that. It is recommended you break each batch up in 1,000 increements. So if you need to send to 5,000 emails, then you'd break this into a loop of 1,000 emails at a time.
@@ -333,18 +370,6 @@ $email->setFrom("from@mailinator.com")->
 $result = $sendgrid->send($email);
 ```
 
-### Ignoring SSL certificate verification
-
-You can optionally ignore verification of SSL certificate when using the Web API.
-
-```php
-$options = array("turn_off_ssl_verification" => true);
-$sendgrid   = new SendGrid(SENDGRID_USERNAME, SENDGRID_PASSWORD, $options);
-
-$email      = new SendGrid\Email();
-...
-$result     = $sendgrid->send($email);
-```
 
 ## Contributing
 

--- a/lib/SendGrid.php
+++ b/lib/SendGrid.php
@@ -20,6 +20,14 @@ class SendGrid {
     if( !isset($options["turn_off_ssl_verification"]) ){
       $options["turn_off_ssl_verification"] = false;
     }
+    
+
+    $protocol = isset($options['protocol']) ? $options['protocol'] : 'https';
+    $host = isset($options['host']) ? $options['host'] : 'api.sendgrid.com';
+    $port = isset($options['port']) ? $options['port'] : '';
+    $endpoint = isset($options['endpoint']) ? $options['endpoint'] : '/api/mail.send.json';
+
+    $this->url = isset($options['url']) ? $options['url'] : $protocol . "://" . $host . ($port ? ":" . $port : "") . $endpoint;
 
     $this->options  = $options;
   }

--- a/test/SendGrid.php
+++ b/test/SendGrid.php
@@ -11,6 +11,17 @@ class SendGridTest_SendGrid extends PHPUnit_Framework_TestCase {
     $this->assertEquals("SendGrid", get_class($sendgrid));
   }
 
+  public function testDefaultURL() {
+    $sendgrid = new SendGrid("user", "pass");
+    $this->assertEquals("https://api.sendgrid.com/api/mail.send.json", $sendgrid->url);
+  }
+
+  public function testCustomURL() {
+    $options = array( "protocol" => "http", "host" => "sendgrid.org", "endpoint" => "/send", "port" => "80" );
+    $sendgrid = new SendGrid("user", "pass", $options);
+    $this->assertEquals("http://sendgrid.org:80/send", $sendgrid->url);
+  }
+
   public function testSendResponse() {
     $sendgrid = new SendGrid("foo", "bar");
 


### PR DESCRIPTION
This does not follow the newly discussed standard: scottmotte/sendgrid-opensource-proposals@479627b as I made these code changes prior to it being posted.

Do you feel it's good to add this now (even though it may not be what we eventually determine) or keep the code change from occurring until the true standard is determined?

We can always point people to this PR if they need to change the URL at present.
