### PR TITLE
Fixes the turn_off_ssl_verification option so that it works with cURL.

### DIFF
--- a/lib/SendGrid.php
+++ b/lib/SendGrid.php
@@ -51,7 +51,7 @@ class SendGrid {
     curl_setopt($ch, CURLOPT_POSTFIELDS, $form);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
     curl_setopt($ch, CURLOPT_USERAGENT, 'sendgrid/' . $this->version . ';php');
-    curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, $this->options['turn_off_ssl_verification']);
+    curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, !$this->options['turn_off_ssl_verification']);
 
     $response = curl_exec($ch);
 


### PR DESCRIPTION
I noticed that the **turn_off_ssl_verification** option was no longer working in the latest version. I tracked the bug down with the switch to cURL. Under the hood it was directly using the value of **turn_off_ssl_verification** to set the cURL flag **CURLOPT_SSL_VERIFYPEER** but they actually have the opposite boolean meaning.

CURLOPT_SSL_VERIFYPEER
- FALSE to stop cURL from verifying the peer's certificate. Alternate certificates to verify against can be specified with the CURLOPT_CAINFO option or a certificate directory can be specified with the CURLOPT_CAPATH option.

Reference: http://php.net/manual/en/function.curl-setopt.php (CURLOPT_SSL_VERIFYPEER)