### PR TITLE
Bug fix: correctly encode arrays

### DIFF
--- a/lib/SendGrid.php
+++ b/lib/SendGrid.php
@@ -48,7 +48,7 @@ class SendGrid {
 
     curl_setopt($ch, CURLOPT_URL, $this->url);
     curl_setopt($ch, CURLOPT_POST, 1);
-    curl_setopt($ch, CURLOPT_POSTFIELDS, $form);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($form));
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
     curl_setopt($ch, CURLOPT_USERAGENT, 'sendgrid/' . $this->version . ';php');
     curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, !$this->options['turn_off_ssl_verification']);


### PR DESCRIPTION
At present adding multiple cc or bcc addresses is broken.

From SendGrid's documentation, multiple cc or bcc addresses should be formatted as: `cc[]=a@mail.com&cc[]=b@mail.com`

However this client was not URL encoding the array before sending, meaning that what was actually sent to SendGrid's API was the string `cc=Array` when more than one cc address was set.

By calling http_build_query(), we ensure that array are encoded as expected.