### PR TITLE
Fix limitations which do not allow to send email with multiple bcc

### DIFF
--- a/lib/SendGrid.php
+++ b/lib/SendGrid.php
@@ -33,7 +33,7 @@ class SendGrid {
     $form['api_user'] = $this->api_user; 
     $form['api_key']  = $this->api_key; 
 
-    $response = $this->makeRequest($form);
+    $response = $this->makeRequest(http_build_query($form));
 
     return $response;
   }


### PR DESCRIPTION
This request would help you to fix a nasty bug - limitations which do not allow to send email with multiple bcc.
When we add multiple bcc, we get a multidimensional array and an error :

 [php] Array to string conversion

in:

vendor/sendgrid/sendgrid/lib/SendGrid.php:51