### PR TITLE
New version of Sengrid-PHP for Guzzle 6.x support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 before_script:
-- phpenv local 5.4
+- phpenv local 5.5
 - composer install --dev --no-interaction
 - phpenv local --unset
 - cd test
@@ -8,28 +8,15 @@ script:
 - "../vendor/bin/phpunit --coverage-clover clover.xml"
 after_script:
 - cd ..
-- phpenv local 5.4
+- phpenv local 5.5
 - phpenv local --unset
-- "./scripts/s3upload.sh"
 php:
-- 5.3
-- 5.4
 - 5.5
 - 5.6
 env:
   global:
-  - S3_POLICY: ewogICJleHBpcmF0aW9uIjogIjIxMDAtMDEtMDFUMTI6MDA6MDAuMDAwWiIsCiAgImNvbmRpdGlvbnMiOiBbCiAgICB7ImFjbCI6ICJwdWJsaWMtcmVhZCIgfSwKICAgIHsiYnVja2V0IjogInNlbmRncmlkLW9wZW4tc291cmNlIiB9LAogICAgWyJzdGFydHMtd2l0aCIsICIka2V5IiwgInNlbmRncmlkLXBocC8iXSwKICAgIFsiY29udGVudC1sZW5ndGgtcmFuZ2UiLCAyMDQ4LCAyNjg0MzU0NTZdLAogICAgWyJlcSIsICIkQ29udGVudC1UeXBlIiwgImFwcGxpY2F0aW9uL3ppcCJdCiAgXQp9Cgo=
   - secure: eUN0huKA436uIkISu6V3yW01/gZHC6slBvlnprMPEhzclU2szH6qhWEXWS5CcOG6EEDBReqLZdNAwu+FC69KGFO9+6oW2GQQLSsfEViqFi/Ig2N0r4EBO4jLRebgq0GOfetPwQvJH27d8BCiloPy8rXBb5pskxSNw4B4bRyXHz4=
   - secure: j38xzMNmzYXR/JJdVumPmDoDVxb6FUDF497AuVPHowGh0egFW8XHWCOMeQWqWZI4Gg17pViQNIJ3xC6WBvob70AF8fsNm0+vxF2s7abXDMcbq5flLTS6ydKLgNu+na/RAkOBbTwxJAGIH/fQh8BH8iGKerCwoqf8sDErAge4NMw=
   - secure: h3HlxBOsNXBDrIJ0yl467ST6Q8R2TmbL7PltlPcRoHy5gAxn5UiDv5W2+6DSXrwQrTjOUunZ+O9ckcaQGQy1JNhGMwgIkJpyWAHDIHhTYGU289uUIDTHQW/soX0qHJSHSx3iMgDOIc7XnfTz6W7Nv1gYKZFedOMsZ5uBMeGyiXE=
   - secure: SKSl/RHFQNhGT7OUj7E0AbrQnuDhhCRI/4jC76mmzvy8EJBDgUNevAKJGtug+LVilHrlbk9fLC8rayPW6SGv0s3PowTGm8NMOc48aRBLOr7QRo/sMikJCmRuU6HWptr0NKuf2fq6lV94WDm/pDdyOSNyLga9/eaIDs/Sacp78sw=
-notifications:
-  hipchat:
-    rooms:
-      secure: l4RUOBY44kVhSxx54NU3cmvn598rRMB7Y272Ct/W0fBm1tdGncp42A/rwg7JkiZH9EWXs3tKtoSjqw5xT6QeScUGQDdykS5QVO8lEIkDRGD4WwQ3VDJmRy1+04WtgqFEK8SyYTCcCl4ZJ0rtOcJZgDMvigkOJuLxwGXTDuvfu1k=
-    template:
-    - '<a href="https://travis-ci.org/%{repository}/builds/%{build_id}">%{repository}
-      Build %{build_number}</a> on branch <i>%{branch}</i> by %{author}: <strong>%{message}</strong>
-      <a href="https://github.com/sendgrid/docs/commits/%{commit}">View on GitHub</a>'
-    format: html
-    notify: true
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [vX.X.X] - (2015-08-23)
+### Added
+- Upgrade to Guzzle 6.x
+
 ## [v3.2.0] - (2015-05-13)
 ### Added
 - Specify Guzzle proxy via [#149](https://github.com/sendgrid/sendgrid-php/pull/149)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The `send()` method now raises a `\SendGrid\Exception` by default if the respons
 
 ---
 
-Important: This library requires PHP 5.3 or higher.
+Important: This library requires PHP 5.5 or higher.
 
 [![BuildStatus](https://travis-ci.org/sendgrid/sendgrid-php.svg?branch=master)](https://travis-ci.org/sendgrid/sendgrid-php)
 [![Latest Stable Version](https://poser.pugx.org/sendgrid/sendgrid/version.svg)](https://packagist.org/packages/sendgrid/sendgrid)
@@ -196,12 +196,12 @@ object(SendGrid\Response)#31 (4) {
   ["code"]=>
   int(200)
   ["headers"]=>
-  object(Guzzle\Http\Message\Header\HeaderCollection)#48 (1) {
+  object(GuzzleHttp\Message\Header\HeaderCollection)#48 (1) {
     ["headers":protected]=>
     array(6) {
 	...
       ["content-type"]=>
-      object(Guzzle\Http\Message\Header)#41 (3) {
+      object(GuzzleHttp\Message\Header)#41 (3) {
         ["values":protected]=>
         array(1) {
           [0]=>

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Returns the status code of the response.
 
 #### getHeaders ####
 
-Returns the headers of the response as a [Guzzle\Http\Message\Header\HeaderCollection object](http://api.guzzlephp.org/class-Guzzle.Http.Message.Header.HeaderCollection.html).
+Returns the headers of the response as a array. Keys are the response identifiers such as "Authorization"
 
 #### getRawBody ####
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SendGrid-PHP
 
+**This is a forked version of SendGrid-PHP which uses Guzzle 6.x**
+
 This library allows you to quickly and easily send emails through SendGrid using PHP.
 
 WARNING: This module was recently upgraded from [2.2.x](https://github.com/sendgrid/sendgrid-php/tree/v2.2.1) to 3.X. There were API breaking changes for various method names. See [usage](https://github.com/sendgrid/sendgrid-php#usage) for up to date method names.

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ The `send()` method now raises a `\SendGrid\Exception` by default if the respons
 
 Important: This library requires PHP 5.5 or higher.
 
-[![BuildStatus](https://travis-ci.org/sendgrid/sendgrid-php.svg?branch=master)](https://travis-ci.org/sendgrid/sendgrid-php)
-[![Latest Stable Version](https://poser.pugx.org/sendgrid/sendgrid/version.svg)](https://packagist.org/packages/sendgrid/sendgrid)
+[![BuildStatus](https://travis-ci.org/taz77/sendgrid-php.svg?branch=master)](https://travis-ci.org/taz77/sendgrid-php.svg?branch=master)
+
 
 ```php
 $sendgrid = new SendGrid('username', 'password');

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   "require": {
     "php": ">=5.3",
     "sendgrid/smtpapi": "~0.5",
-    "guzzle/guzzle": "~3.9"
+    "guzzlehttp/guzzle": ">=6.0.0"
   },
   "require-dev": {
     "mockery/mockery": "~0.9",

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   "require": {
     "php": ">=5.3",
     "sendgrid/smtpapi": "~0.5",
-    "guzzlehttp/guzzle": ">=6.0.0"
+    "guzzlehttp/guzzle": "~6.0"
   },
   "require-dev": {
     "mockery/mockery": "~0.9",

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   "require": {
     "php": ">=5.3",
     "sendgrid/smtpapi": "~0.5",
-    "guzzlehttp/guzzle": "~6.0"
+    "guzzlehttp/guzzle": ">=6.0.0"
   },
   "require-dev": {
     "mockery/mockery": "~0.9",

--- a/lib/SendGrid.php
+++ b/lib/SendGrid.php
@@ -1,7 +1,8 @@
 <?php
 
-class SendGrid
-{
+use GuzzleHttp\Exception\ClientException;
+
+class SendGrid {
     const VERSION = '3.2.0';
 
     protected
@@ -17,38 +18,39 @@ class SendGrid
         $endpoint,
         $version = self::VERSION;
 
-    public function __construct($apiUserOrKey, $apiKeyOrOptions = null, $options = array())
-    {
-        // Check if given a username + password or api key
+    public function __construct($apiUserOrKey, $apiKeyOrOptions = NULL, $options = array()) {
+        // Check if given a username + password or api key.
         if (is_string($apiKeyOrOptions)) {
-            // Username and password
+            // Username and password.
             $this->apiUser = $apiUserOrKey;
             $this->apiKey = $apiKeyOrOptions;
             $this->options = $options;
-        } elseif (is_array($apiKeyOrOptions) || $apiKeyOrOptions === null) {
-            // API key
+        }
+        elseif (is_array($apiKeyOrOptions) || $apiKeyOrOptions === NULL) {
+            // API key.
             $this->apiKey = $apiUserOrKey;
-            $this->apiUser = null;
+            $this->apiUser = NULL;
 
-            // With options
+            // With options.
             if (is_array($apiKeyOrOptions)) {
                 $this->options = $apiKeyOrOptions;
             }
-        } else {
+        }
+        else {
             // Won't be thrown?
             throw new InvalidArgumentException('Need a username + password or api key!');
         }
 
-        $this->options['turn_off_ssl_verification'] = (isset($this->options['turn_off_ssl_verification']) && $this->options['turn_off_ssl_verification'] == true);
+        $this->options['turn_off_ssl_verification'] = (isset($this->options['turn_off_ssl_verification']) && $this->options['turn_off_ssl_verification'] == TRUE);
         if (!isset($this->options['raise_exceptions'])) {
-            $this->options['raise_exceptions'] = true;
+            $this->options['raise_exceptions'] = TRUE;
         }
         $protocol = isset($this->options['protocol']) ? $this->options['protocol'] : 'https';
-        $host = isset($this->options['host']) ? $this->options['host'] : 'api.sendgrid.com';
+        $host = isset($this->options['host']) ? $this->options['host'] : 'api.sendgrid.com/api/';
         $port = isset($this->options['port']) ? $this->options['port'] : '';
 
         $this->url = isset($this->options['url']) ? $this->options['url'] : $protocol . '://' . $host . ($port ? ':' . $port : '');
-        $this->endpoint = isset($this->options['endpoint']) ? $this->options['endpoint'] : '/api/mail.send.json';
+        $this->endpoint = isset($this->options['endpoint']) ? $this->options['endpoint'] : 'mail.send.json';
 
         $this->client = $this->prepareHttpClient();
     }
@@ -58,31 +60,36 @@ class SendGrid
      *
      * @return \GuzzleHttp\Client
      */
-    private function prepareHttpClient()
-    {
+    private function prepareHttpClient() {
         $headers = array();
-        $headers['verify'] = !$this->options['turn_off_ssl_verification'];
+        // $headers['verify'] = !$this->options['turn_off_ssl_verification'];
         // Using api key
-        if ($this->apiUser === null) {
-            $headers['Authorizaton'] = 'Bearer' . ' ' . $this->apiKey;
+        if ($this->apiUser === NULL) {
+            $headers['Authorization'] = 'Bearer' . ' ' . $this->apiKey;
         }
+        // @TODO Handle a username and password.
 
         // Using http proxy
         if (isset($this->options['proxy'])) {
             $headers['proxy'] = $this->options['proxy'];
         }
         $headers['User-Agent'] = 'sendgrid/' . $this->version . ';php';
+        // Create an empty stack for error processing.
+        // Guzzlehttp will choose the most appropriate handler based on the system.
+        $stack = \GuzzleHttp\HandlerStack::create();
 
-        $client = new \GuzzleHttp\Client(['base_uri' => $this->url, 'headers' => [$headers]]);
-
+        $client = new \GuzzleHttp\Client([
+            'base_uri' => $this->url,
+            'headers' => $headers,
+            'handler' => $stack
+        ]);
         return $client;
     }
 
     /**
      * @return array The protected options array
      */
-    public function getOptions()
-    {
+    public function getOptions() {
         return $this->options;
     }
 
@@ -94,12 +101,12 @@ class SendGrid
      * @throws SendGrid\Exception if the response code is not 200
      * @return stdClass SendGrid response object
      */
-    public function send(SendGrid\Email $email)
-    {
+    public function send(SendGrid\Email $email) {
         $form = $email->toWebFormat();
-
+        //$this->request = new \GuzzleHttp\Psr7\Request('POST', $this->url . $this->endpoint);
+        // @TODO Add username/password to the header.
         // Using username password
-        if ($this->apiUser !== null) {
+        if ($this->apiUser !== NULL) {
             $form['api_user'] = $this->apiUser;
             $form['api_key'] = $this->apiKey;
         }
@@ -121,24 +128,24 @@ class SendGrid
      *
      * @return SendGrid\Response
      */
-    public function postRequest($endpoint, $form)
-    {
-        $req = $this->client->post($endpoint, null, $form);
-
-        $res = $req->send();
-
-        $response = new SendGrid\Response($res->getStatusCode(), $res->getHeaders(), $res->getBody(true), $res->json());
+    public function postRequest($endpoint, $form) {
+        try {
+            $res = $this->client->post($endpoint, ['query' => $form]);
+        }
+        catch (GuzzleHttp\Exception\ClientException $e) {
+            echo 'Sendgrid API has experienced and error completing your request.';
+            var_dump($e);
+        }
+        $response = new SendGrid\Response($res->getStatusCode(), $res->getHeaders(), $res->getBody(TRUE), json_decode($res->getBody(TRUE)));
 
         return $response;
     }
 
-    public static function register_autoloader()
-    {
+    public static function register_autoloader() {
         spl_autoload_register(array('SendGrid', 'autoloader'));
     }
 
-    public static function autoloader($class)
-    {
+    public static function autoloader($class) {
         // Check that the class starts with 'SendGrid'
         if ($class == 'SendGrid' || stripos($class, 'SendGrid\\') === 0) {
             $file = str_replace('\\', '/', $class);

--- a/lib/SendGrid.php
+++ b/lib/SendGrid.php
@@ -56,29 +56,24 @@ class SendGrid
     /**
      * Prepares the HTTP client
      *
-     * @return \Guzzle\Http\Client
+     * @return \GuzzleHttp\Client
      */
     private function prepareHttpClient()
     {
-        $guzzleOption = array(
-            'request.options' => array(
-                'verify' => !$this->options['turn_off_ssl_verification'],
-                'exceptions' => (isset($this->options['enable_guzzle_exceptions']) && $this->options['enable_guzzle_exceptions'] == true)
-            )
-        );
-
+        $headers = array();
+        $headers['verify'] = !$this->options['turn_off_ssl_verification'];
         // Using api key
         if ($this->apiUser === null) {
-            $guzzleOption['request.options']['headers'] = array('Authorization' => 'Bearer ' . $this->apiKey);
+            $headers['Authorizaton'] = 'Bearer' . ' ' . $this->apiKey;
         }
 
         // Using http proxy
         if (isset($this->options['proxy'])) {
-            $guzzleOption['request.options']['proxy'] = $this->options['proxy'];
+            $headers['proxy'] = $this->options['proxy'];
         }
+        $headers['User-Agent'] = 'sendgrid/' . $this->version . ';php';
 
-        $client = new \GuzzleHttp\Client($this->url, $guzzleOption);
-        $client->setUserAgent('sendgrid/' . $this->version . ';php');
+        $client = new \GuzzleHttp\Client(['base_uri' => $this->url, 'headers' => [$headers]]);
 
         return $client;
     }

--- a/lib/SendGrid.php
+++ b/lib/SendGrid.php
@@ -46,11 +46,11 @@ class SendGrid {
             $this->options['raise_exceptions'] = TRUE;
         }
         $protocol = isset($this->options['protocol']) ? $this->options['protocol'] : 'https';
-        $host = isset($this->options['host']) ? $this->options['host'] : 'api.sendgrid.com/api/';
+        $host = isset($this->options['host']) ? $this->options['host'] : 'api.sendgrid.com';
         $port = isset($this->options['port']) ? $this->options['port'] : '';
 
         $this->url = isset($this->options['url']) ? $this->options['url'] : $protocol . '://' . $host . ($port ? ':' . $port : '');
-        $this->endpoint = isset($this->options['endpoint']) ? $this->options['endpoint'] : 'mail.send.json';
+        $this->endpoint = isset($this->options['endpoint']) ? $this->options['endpoint'] : '/api/mail.send.json';
 
         $this->client = $this->prepareHttpClient();
     }

--- a/lib/SendGrid.php
+++ b/lib/SendGrid.php
@@ -135,6 +135,7 @@ class SendGrid {
         catch (GuzzleHttp\Exception\ClientException $e) {
             echo 'Sendgrid API has experienced and error completing your request.';
             var_dump($e);
+            return FALSE;
         }
         $response = new SendGrid\Response($res->getStatusCode(), $res->getHeaders(), $res->getBody(TRUE), json_decode($res->getBody(TRUE)));
 

--- a/lib/SendGrid.php
+++ b/lib/SendGrid.php
@@ -77,7 +77,7 @@ class SendGrid
             $guzzleOption['request.options']['proxy'] = $this->options['proxy'];
         }
 
-        $client = new \Guzzle\Http\Client($this->url, $guzzleOption);
+        $client = new \GuzzleHttp\Client($this->url, $guzzleOption);
         $client->setUserAgent('sendgrid/' . $this->version . ';php');
 
         return $client;

--- a/lib/SendGrid.php
+++ b/lib/SendGrid.php
@@ -130,7 +130,7 @@ class SendGrid {
      */
     public function postRequest($endpoint, $form) {
         try {
-            $res = $this->client->post($endpoint, ['query' => $form]);
+            $res = $this->client->post($endpoint, ['form_params' => $form]);
         }
         catch (GuzzleHttp\Exception\ClientException $e) {
             echo 'Sendgrid API has experienced and error completing your request.';

--- a/lib/SendGrid/Email.php
+++ b/lib/SendGrid/Email.php
@@ -2,8 +2,7 @@
 
 namespace SendGrid;
 
-class Email
-{
+class Email {
     public
         $to,
         $toName,
@@ -23,10 +22,9 @@ class Email
         $smtpapi,
         $attachments;
 
-    public function __construct()
-    {
-        $this->fromName = false;
-        $this->replyTo = false;
+    public function __construct() {
+        $this->fromName = FALSE;
+        $this->replyTo = FALSE;
         $this->smtpapi = new \Smtpapi\Header();
     }
 
@@ -38,14 +36,14 @@ class Email
      * @param Array $list - the list of key/value pairs
      * @param String $item - the value to be removed
      */
-    private function _removeFromList(&$list, $item, $key_field = null)
-    {
+    private function _removeFromList(&$list, $item, $key_field = NULL) {
         foreach ($list as $key => $val) {
             if ($key_field) {
                 if ($val[$key_field] == $item) {
                     unset($list[$key]);
                 }
-            } else {
+            }
+            else {
                 if ($val == $item) {
                     unset($list[$key]);
                 }
@@ -55,9 +53,8 @@ class Email
         $list = array_values($list);
     }
 
-    public function addTo($email, $name = null)
-    {
-        if ($this->to == null) {
+    public function addTo($email, $name = NULL) {
+        if ($this->to == NULL) {
             $this->to = array();
         }
 
@@ -65,7 +62,8 @@ class Email
             foreach ($email as $e) {
                 $this->to[] = $e;
             }
-        } else {
+        }
+        else {
             $this->to[] = $email;
         }
 
@@ -73,37 +71,34 @@ class Email
             foreach ($name as $n) {
                 $this->addToName($n);
             }
-        } elseif ($name) {
+        }
+        elseif ($name) {
             $this->addToName($name);
         }
 
         return $this;
     }
 
-    public function addSmtpapiTo($email, $name = null)
-    {
+    public function addSmtpapiTo($email, $name = NULL) {
         $this->smtpapi->addTo($email, $name);
 
         return $this;
     }
 
-    public function setTos(array $emails)
-    {
+    public function setTos(array $emails) {
         $this->to = $emails;
 
         return $this;
     }
 
-    public function setSmtpapiTos(array $emails)
-    {
+    public function setSmtpapiTos(array $emails) {
         $this->smtpapi->setTos($emails);
 
         return $this;
     }
 
-    public function addToName($name)
-    {
-        if ($this->toName == null) {
+    public function addToName($name) {
+        if ($this->toName == NULL) {
             $this->toName = array();
         }
 
@@ -112,68 +107,59 @@ class Email
         return $this;
     }
 
-    public function getToNames()
-    {
+    public function getToNames() {
         return $this->toName;
     }
 
-    public function setFrom($email)
-    {
+    public function setFrom($email) {
         $this->from = $email;
 
         return $this;
     }
 
-    public function getFrom($as_array = false)
-    {
+    public function getFrom($as_array = FALSE) {
         if ($as_array && ($name = $this->getFromName())) {
             return array("$this->from" => $name);
-        } else {
+        }
+        else {
             return $this->from;
         }
     }
 
-    public function setFromName($name)
-    {
+    public function setFromName($name) {
         $this->fromName = $name;
 
         return $this;
     }
 
-    public function getFromName()
-    {
+    public function getFromName() {
         return $this->fromName;
     }
 
-    public function setReplyTo($email)
-    {
+    public function setReplyTo($email) {
         $this->replyTo = $email;
 
         return $this;
     }
 
-    public function getReplyTo()
-    {
+    public function getReplyTo() {
         return $this->replyTo;
     }
 
-    public function setCc($email)
-    {
+    public function setCc($email) {
         $this->cc = array($email);
 
         return $this;
     }
 
-    public function setCcs(array $email_list)
-    {
+    public function setCcs(array $email_list) {
         $this->cc = $email_list;
 
         return $this;
     }
 
-    public function addCc($email, $name = null)
-    {
-        if ($this->cc == null) {
+    public function addCc($email, $name = NULL) {
+        if ($this->cc == NULL) {
             $this->cc = array();
         }
 
@@ -181,7 +167,8 @@ class Email
             foreach ($email as $e) {
                 $this->cc[] = $e;
             }
-        } else {
+        }
+        else {
             $this->cc[] = $email;
         }
 
@@ -189,16 +176,16 @@ class Email
             foreach ($name as $n) {
                 $this->addCcName($n);
             }
-        } elseif ($name) {
+        }
+        elseif ($name) {
             $this->addCcName($name);
         }
 
         return $this;
     }
 
-    public function addCcName($name)
-    {
-        if ($this->ccName == null) {
+    public function addCcName($name) {
+        if ($this->ccName == NULL) {
             $this->ccName = array();
         }
 
@@ -207,40 +194,34 @@ class Email
         return $this;
     }
 
-    public function removeCc($email)
-    {
+    public function removeCc($email) {
         $this->_removeFromList($this->cc, $email);
 
         return $this;
     }
 
-    public function getCcs()
-    {
+    public function getCcs() {
         return $this->cc;
     }
 
-    public function getCcNames()
-    {
+    public function getCcNames() {
         return $this->ccName;
     }
 
-    public function setBcc($email)
-    {
+    public function setBcc($email) {
         $this->bcc = array($email);
 
         return $this;
     }
 
-    public function setBccs($email_list)
-    {
+    public function setBccs($email_list) {
         $this->bcc = $email_list;
 
         return $this;
     }
 
-    public function addBcc($email, $name = null)
-    {
-        if ($this->bcc == null) {
+    public function addBcc($email, $name = NULL) {
+        if ($this->bcc == NULL) {
             $this->bcc = array();
         }
 
@@ -248,7 +229,8 @@ class Email
             foreach ($email as $e) {
                 $this->bcc[] = $e;
             }
-        } else {
+        }
+        else {
             $this->bcc[] = $email;
         }
 
@@ -256,16 +238,16 @@ class Email
             foreach ($name as $n) {
                 $this->addBccName($n);
             }
-        } elseif ($name) {
+        }
+        elseif ($name) {
             $this->addBccName($name);
         }
 
         return $this;
     }
 
-    public function addBccName($name)
-    {
-        if ($this->bccName == null) {
+    public function addBccName($name) {
+        if ($this->bccName == NULL) {
             $this->bccName = array();
         }
 
@@ -274,87 +256,73 @@ class Email
         return $this;
     }
 
-    public function getBccNames()
-    {
+    public function getBccNames() {
         return $this->bccName;
     }
 
-    public function removeBcc($email)
-    {
+    public function removeBcc($email) {
         $this->_removeFromList($this->bcc, $email);
 
         return $this;
     }
 
-    public function getBccs()
-    {
+    public function getBccs() {
         return $this->bcc;
     }
 
-    public function setSubject($subject)
-    {
+    public function setSubject($subject) {
         $this->subject = $subject;
 
         return $this;
     }
 
-    public function getSubject()
-    {
+    public function getSubject() {
         return $this->subject;
     }
 
-    public function setDate($date)
-    {
+    public function setDate($date) {
         $this->date = $date;
 
         return $this;
     }
 
-    public function getDate()
-    {
+    public function getDate() {
         return $this->date;
     }
 
-    public function setText($text)
-    {
+    public function setText($text) {
         $this->text = $text;
 
         return $this;
     }
 
-    public function getText()
-    {
+    public function getText() {
         return $this->text;
     }
 
-    public function setHtml($html)
-    {
+    public function setHtml($html) {
         $this->html = $html;
 
         return $this;
     }
 
-    public function getHtml()
-    {
+    public function getHtml() {
         return $this->html;
     }
 
-    public function setSendAt($timestamp)
-    {
+    public function setSendAt($timestamp) {
         $this->smtpapi->setSendAt($timestamp);
 
         return $this;
     }
 
-    public function setSendEachAt(array $timestamps)
-    {
+    public function setSendEachAt(array $timestamps) {
         $this->smtpapi->setSendEachAt($timestamps);
 
         return $this;
     }
 
-    public function addSendEachAt($timestamp)
-    {
+    public function addSendEachAt($timestamp) {
         $this->smtpapi->addSendEachAt($timestamp);
 
         return $this;
@@ -367,8 +335,7 @@ class Email
      *
      * @return $this
      */
-    public function setTemplateId($templateId)
-    {
+    public function setTemplateId($templateId) {
         $this->addFilter('templates', 'enabled', 1);
         $this->addFilter('templates', 'template_id', $templateId);
 
@@ -381,21 +348,20 @@ class Email
      *
      * @return $this
      */
-    public function setAsmGroupId($groupId)
-    {
+    public function setAsmGroupId($groupId) {
         $this->smtpapi->setASMGroupID($groupId);
 
         return $this;
     }
 
-    public function setAttachments(array $files)
-    {
+    public function setAttachments(array $files) {
         $this->attachments = array();
 
         foreach ($files as $filename => $file) {
             if (is_string($filename)) {
                 $this->addAttachment($file, $filename);
-            } else {
+            }
+            else {
                 $this->addAttachment($file);
             }
         }
@@ -403,214 +369,189 @@ class Email
         return $this;
     }
 
-    public function setAttachment($file, $custom_filename = null, $cid = null)
-    {
+    public function setAttachment($file, $custom_filename = NULL, $cid = NULL) {
         $this->attachments = array($this->getAttachmentInfo($file, $custom_filename, $cid));
 
         return $this;
     }
 
-    public function addAttachment($file, $custom_filename = null, $cid = null)
-    {
+    public function addAttachment($file, $custom_filename = NULL, $cid = NULL) {
         $this->attachments[] = $this->getAttachmentInfo($file, $custom_filename, $cid);
 
         return $this;
     }
 
-    public function getAttachments()
-    {
+    public function getAttachments() {
         return $this->attachments;
     }
 
-    public function removeAttachment($file)
-    {
+    public function removeAttachment($file) {
         $this->_removeFromList($this->attachments, $file, "file");
 
         return $this;
     }
 
-    private function getAttachmentInfo($file, $custom_filename = null, $cid = null)
-    {
+    private function getAttachmentInfo($file, $custom_filename = NULL, $cid = NULL) {
         $info = pathinfo($file);
         $info['file'] = $file;
         if (!is_null($custom_filename)) {
             $info['custom_filename'] = $custom_filename;
         }
-        if ($cid !== null) {
+        if ($cid !== NULL) {
             $info['cid'] = $cid;
         }
 
         return $info;
     }
 
-    public function setCategories($categories)
-    {
+    public function setCategories($categories) {
         $this->smtpapi->setCategories($categories);
 
         return $this;
     }
 
-    public function setCategory($category)
-    {
+    public function setCategory($category) {
         $this->smtpapi->setCategory($category);
 
         return $this;
     }
 
-    public function addCategory($category)
-    {
+    public function addCategory($category) {
         $this->smtpapi->addCategory($category);
 
         return $this;
     }
 
-    public function removeCategory($category)
-    {
+    public function removeCategory($category) {
         $this->smtpapi->removeCategory($category);
 
         return $this;
     }
 
-    public function setSubstitutions($key_value_pairs)
-    {
+    public function setSubstitutions($key_value_pairs) {
         $this->smtpapi->setSubstitutions($key_value_pairs);
 
         return $this;
     }
 
-    public function addSubstitution($from_value, array $to_values)
-    {
+    public function addSubstitution($from_value, array $to_values) {
         $this->smtpapi->addSubstitution($from_value, $to_values);
 
         return $this;
     }
 
-    public function setSections(array $key_value_pairs)
-    {
+    public function setSections(array $key_value_pairs) {
         $this->smtpapi->setSections($key_value_pairs);
 
         return $this;
     }
 
-    public function addSection($from_value, $to_value)
-    {
+    public function addSection($from_value, $to_value) {
         $this->smtpapi->addSection($from_value, $to_value);
 
         return $this;
     }
 
-    public function setUniqueArgs(array $key_value_pairs)
-    {
+    public function setUniqueArgs(array $key_value_pairs) {
         $this->smtpapi->setUniqueArgs($key_value_pairs);
 
         return $this;
     }
 
     ## synonym method
-    public function setUniqueArguments(array $key_value_pairs)
-    {
+    public function setUniqueArguments(array $key_value_pairs) {
         $this->smtpapi->setUniqueArgs($key_value_pairs);
 
         return $this;
     }
 
-    public function addUniqueArg($key, $value)
-    {
+    public function addUniqueArg($key, $value) {
         $this->smtpapi->addUniqueArg($key, $value);
 
         return $this;
     }
 
     ## synonym method
-    public function addUniqueArgument($key, $value)
-    {
+    public function addUniqueArgument($key, $value) {
         $this->smtpapi->addUniqueArg($key, $value);
 
         return $this;
     }
 
-    public function setFilters($filter_settings)
-    {
+    public function setFilters($filter_settings) {
         $this->smtpapi->setFilters($filter_settings);
 
         return $this;
     }
 
     ## synonym method
-    public function setFilterSettings($filter_settings)
-    {
+    public function setFilterSettings($filter_settings) {
         $this->smtpapi->setFilters($filter_settings);
 
         return $this;
     }
 
-    public function addFilter($filter_name, $parameter_name, $parameter_value)
-    {
+    public function addFilter($filter_name, $parameter_name, $parameter_value) {
         $this->smtpapi->addFilter($filter_name, $parameter_name, $parameter_value);
 
         return $this;
     }
 
     ## synonym method
-    public function addFilterSetting($filter_name, $parameter_name, $parameter_value)
-    {
+    public function addFilterSetting($filter_name, $parameter_name, $parameter_value) {
         $this->smtpapi->addFilter($filter_name, $parameter_name, $parameter_value);
 
         return $this;
     }
 
-    public function getHeaders()
-    {
+    public function getHeaders() {
         return $this->headers;
     }
 
-    public function getHeadersJson()
-    {
+    public function getHeadersJson() {
         if (count($this->getHeaders()) <= 0) {
-            return "{}";
+            return NULL;
         }
 
         return json_encode($this->getHeaders(), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP);
     }
 
-    public function setHeaders($key_value_pairs)
-    {
+    public function setHeaders($key_value_pairs) {
         $this->headers = $key_value_pairs;
 
         return $this;
     }
 
-    public function addHeader($key, $value)
-    {
+    public function addHeader($key, $value) {
         $this->headers[$key] = $value;
 
         return $this;
     }
 
-    public function removeHeader($key)
-    {
+    public function removeHeader($key) {
         unset($this->headers[$key]);
 
         return $this;
     }
 
-    public function getSmtpapi()
-    {
+    public function getSmtpapi() {
         return $this->smtpapi;
     }
 
-    public function toWebFormat()
-    {
+    public function toWebFormat() {
         $web = array(
             'to' => $this->to,
             'from' => $this->getFrom(),
-            'x-smtpapi' => $this->smtpapi->jsonString(),
             'subject' => $this->getSubject(),
             'text' => $this->getText(),
             'html' => $this->getHtml(),
-            'headers' => $this->getHeadersJson(),
         );
-
+        if (!empty($this->smtpapi->jsonString()) || $this->smtpapi->jsonString() != '{}') {
+            $web['x-smtpapi'] = $this->smtpapi->jsonString();
+        }
+        if (!empty($this->getHeadersJson()) || $this->getHeadersJson() != '{}') {
+            $web['headers'] = $this->getHeadersJson();
+        }
         if ($this->getToNames()) {
             $web['toname'] = $this->getToNames();
         }
@@ -644,7 +585,7 @@ class Email
         if ($this->getAttachments()) {
             foreach ($this->getAttachments() as $f) {
                 $file = $f['file'];
-                $extension = null;
+                $extension = NULL;
                 if (array_key_exists('extension', $f)) {
                     $extension = $f['extension'];
                 };
@@ -681,8 +622,7 @@ class Email
      * There needs to be at least 1 to address, or else the mail won't send.
      * This method modifies the data that will be sent via either Rest
      */
-    public function updateMissingTo($data)
-    {
+    public function updateMissingTo($data) {
         if ($this->smtpapi->to && (count($this->smtpapi->to) > 0)) {
             $data['to'] = $this->getFrom();
         }


### PR DESCRIPTION
I have been working on a fork of the SendGrid-PHP library to support Guzzle 6.x. This fork only supports PHP 5.5+ and eventually PHP 7.0 as testing with the RC's for PHP 7.0 has started. The decesion to do this was also for my support of the Drupal Sendgrid module. Drupal 8.0 includes Guzzle 6.x making integration really easy for the Drupal CMF for 8.x and beyond. It also supports Drupal 7.x by using the another contrib module that provides Composer.

I made a grave mistake by commiting to master branch in my fork. I should have created a branch! But what is done is done. I updated all the classes and methods and have run Travis CI using my own account and the existing PHPUnit test adapted to exclude PHP 5.3 and 5.4.

I would love for Sendgrid to consider this contribution as a new version of Sendgrid-PHP. This would allow you to continue support for PHP 5.3 by creating a new version of the Sendgrid library.

This pull request isn't meant to be the final version. I know there are other changes that need to be made. This pull request could essentially be looked at as a request to make a new branch in SendGrid-PHP library - a 4.x.x branch.

Lastly, along with the testing. I am using this on a production website via custom composer.json's: https://www.swingsurgeon.com

Thoughts?