### PR TITLE
The addTo should only be called ONCE

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Create a new SendGrid Email object and add your message details.
 $email = new SendGrid\Email();
 $email
     ->addTo('foo@bar.com')
-    ->addTo('bar@foo.com')
+    //->addTo('bar@foo.com') //One of the most notable changes is how `addTo()` behaves. We are now using our Web API parameters instead of the X-SMTPAPI header. What this means is that if you call `addTo()` multiple times for an email, **ONE** email will be sent with each email address visible to everyone.
     ->setFrom('me@bar.com')
     ->setSubject('Subject goes here')
     ->setText('Hello World!')


### PR DESCRIPTION
In the documentation it says that starting versio 3.2.0 addTo should not be called more than once. However, in the example it does just that. So I propose we remove that second line to avoid confusion, no?