### PR TITLE
Add support for ASM Groups to Display parameter when sending mail

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,7 @@
 {
   "name": "sendgrid/sendgrid",
   "description": "This library allows you to quickly and easily send emails through SendGrid using PHP.",
-<<<<<<< HEAD
   "version": "4.1.0",
-=======
-  "version": "4.0.1",
->>>>>>> sendgrid/master
   "homepage": "http://github.com/sendgrid/sendgrid-php",
   "license": "MIT",
   "keywords": ["SendGrid", "sendgrid", "email", "send", "grid"],

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "sendgrid/sendgrid",
   "description": "This library allows you to quickly and easily send emails through SendGrid using PHP.",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "homepage": "http://github.com/sendgrid/sendgrid-php",
   "license": "MIT",
   "keywords": ["SendGrid", "sendgrid", "email", "send", "grid"],

--- a/lib/SendGrid/Email.php
+++ b/lib/SendGrid/Email.php
@@ -388,6 +388,19 @@ class Email
         return $this;
     }
 
+    /** Convenience method to set asm groups to display on the manage preferences page
+     *
+     * @param array the group ids
+     *
+     * @return $this
+     */
+    public function setAsmGroupsToDisplay(array $groupIds)
+    {
+        $this->smtpapi->setASMGroupsToDisplay($groupIds);
+
+        return $this;
+    }
+
     public function setAttachments(array $files)
     {
         $this->attachments = array();

--- a/test/unit/SendGrid/EmailTest.php
+++ b/test/unit/SendGrid/EmailTest.php
@@ -366,6 +366,20 @@ class SendGridTest_Email extends PHPUnit_Framework_TestCase
         $this->assertEquals('my_id', $email->smtpapi->asm_group_id);
     }
 
+    public function testSetAsmGroupsToDisplay()
+    {
+        $email = new SendGrid\Email();
+
+        $ids = array(1,2,3);
+
+        $email->setAsmGroupsToDisplay($ids);
+        $this->assertEquals(count($ids), count($email->smtpapi->asm_groups_to_display));
+
+        for($i = 0; $i < count($ids); $i++) {
+            $this->assertEquals($ids[$i], $email->smtpapi->asm_groups_to_display[$i]);
+        }
+    }
+
     public function testSetText()
     {
         $email = new SendGrid\Email();


### PR DESCRIPTION
Depends on `sendgrid/smtpapi-php` [pull request 11](https://github.com/sendgrid/smtpapi-php/pull/11) being accepted first.