### PR TITLE
Break up the setters in the constructor

### DIFF
--- a/lib/helpers/mail/Mail.php
+++ b/lib/helpers/mail/Mail.php
@@ -917,18 +917,25 @@ class Mail implements \jsonSerializable
     public function __construct($from = null, $subject = null, $to = null, $content = null)
     {
         $from = $from ?: null;
-        $this->setFrom($from);
-        
+        if ($from !== null) {
+            $this->setFrom($from);
+        }
+
         $subject = $subject ?: null;
-        $this->setSubject($subject);
-        
+        if ($subject !== null) {
+            $this->setSubject($subject);
+        }
+
         $content = $content ?: null;
-        $this->addContent($content);
-        
-        if (!empty($to)) {
+        if ($content !== null) {
+            $this->addContent($content);
+        }
+
+        $to = $to ?: null;
+        if ($to !== null) {
             $personalization = new Personalization();
             $personalization->addTo($to);
-            
+
             $this->addPersonalization($personalization);
         }
     }

--- a/lib/helpers/mail/Mail.php
+++ b/lib/helpers/mail/Mail.php
@@ -916,16 +916,21 @@ class Mail implements \jsonSerializable
 
     public function __construct($from = null, $subject = null, $to = null, $content = null)
     {
-        if (!empty($from) &&  !empty($subject) && !empty($to) && !empty($content))
-        {
-            $this->setFrom($from);
+        $from = $from ?: null;
+        $this->setFrom($from);
+        
+        $subject = $subject ?: null;
+        $this->setSubject($subject);
+        
+        $content = $content ?: null;
+        $this->addContent($content);
+        
+        if (!empty($to)) {
             $personalization = new Personalization();
             $personalization->addTo($to);
+            
             $this->addPersonalization($personalization);
-            $this->setSubject($subject);
-            $this->addContent($content);
         }
-
     }
 
     public function setFrom($email)


### PR DESCRIPTION
I would like to suggest breaking up the setters in the constructor. Instead of having it all checked, why not just always set the values, defaulting to null. There null either way. This way it saves time using the constructor. If for example i don't set the `$to` because i want to do it later on trough looping a list. I have to do all the setters manually. With this pull request i would only have to set the `Personalization` manually.
