### PR TITLE
Upgrade sendgrid/php-http-client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ sendgrid-php.php
 composer.phar
 .editorconfig
 test.php
+.idea/

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["SendGrid", "sendgrid", "email", "send", "grid"],
   "require": {
     "php": ">=5.6",
-    "sendgrid/php-http-client": "~3.2"
+    "sendgrid/php-http-client": "3.3"
   },
   "require-dev": {
     "phpunit/phpunit": "4.*",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["SendGrid", "sendgrid", "email", "send", "grid"],
   "require": {
     "php": ">=5.6",
-    "sendgrid/php-http-client": "3.3"
+    "sendgrid/php-http-client": "~3.4"
   },
   "require-dev": {
     "phpunit/phpunit": "4.*",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["SendGrid", "sendgrid", "email", "send", "grid"],
   "require": {
     "php": ">=5.6",
-    "sendgrid/php-http-client": "3.1.0"
+    "sendgrid/php-http-client": "~3.2"
   },
   "require-dev": {
     "phpunit/phpunit": "4.*",

--- a/test/unit/SendGridTest.php
+++ b/test/unit/SendGridTest.php
@@ -63,22 +63,30 @@ class SendGridTest_SendGrid extends \PHPUnit_Framework_TestCase
         $this->assertEquals(json_decode(file_get_contents(__DIR__ . '/../../composer.json'))->version, SendGrid::VERSION);
     }
 
+    private function getProtectedPropertyValueFromObject($object, $propertyName)
+    {
+        $property = new \ReflectionProperty($object, $propertyName);
+        $property->setAccessible(true);
+        return $property->getValue($object);
+    }
+
     public function testSendGrid()
     {
-        $apiKey = "SENDGRID_API_KEY";
+        $apiKey = 'SENDGRID_API_KEY';
         $sg = new SendGrid($apiKey);
         $headers = array(
             'Authorization: Bearer '.$apiKey,
             'User-Agent: sendgrid/' . $sg->version . ';php',
             'Accept: application/json'
-            );
-        $this->assertEquals($sg->client->host, "https://api.sendgrid.com");
-        $this->assertEquals($sg->client->request_headers, $headers);
-        $this->assertEquals($sg->client->version, "/v3");
+        );
 
-        $apiKey = "SENDGRID_API_KEY";
+        $this->assertEquals($this->getProtectedPropertyValueFromObject($sg->client, 'host'), 'https://api.sendgrid.com');
+        $this->assertEquals($this->getProtectedPropertyValueFromObject($sg->client, 'request_headers'), $headers);
+        $this->assertEquals($this->getProtectedPropertyValueFromObject($sg->client, 'version'), '/v3');
+
+        $apiKey = 'SENDGRID_API_KEY';
         $sg2 = new SendGrid($apiKey, array('host' => 'https://api.test.com'));
-        $this->assertEquals($sg2->client->host, "https://api.test.com");
+        $this->assertEquals($this->getProtectedPropertyValueFromObject($sg2->client, 'host'), 'https://api.test.com');
     }
 
     public function test_access_settings_activity_get()

--- a/test/unit/SendGridTest.php
+++ b/test/unit/SendGridTest.php
@@ -81,7 +81,7 @@ class SendGridTest_SendGrid extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals($this->getProtectedPropertyValueFromObject($sg->client, 'host'), 'https://api.sendgrid.com');
-        $this->assertEquals($this->getProtectedPropertyValueFromObject($sg->client, 'request_headers'), $headers);
+        $this->assertEquals($this->getProtectedPropertyValueFromObject($sg->client, 'headers'), $headers);
         $this->assertEquals($this->getProtectedPropertyValueFromObject($sg->client, 'version'), '/v3');
 
         $apiKey = 'SENDGRID_API_KEY';

--- a/test/unit/SendGridTest.php
+++ b/test/unit/SendGridTest.php
@@ -63,13 +63,6 @@ class SendGridTest_SendGrid extends \PHPUnit_Framework_TestCase
         $this->assertEquals(json_decode(file_get_contents(__DIR__ . '/../../composer.json'))->version, SendGrid::VERSION);
     }
 
-    private function getProtectedPropertyValueFromObject($object, $propertyName)
-    {
-        $property = new \ReflectionProperty($object, $propertyName);
-        $property->setAccessible(true);
-        return $property->getValue($object);
-    }
-
     public function testSendGrid()
     {
         $apiKey = 'SENDGRID_API_KEY';
@@ -80,13 +73,13 @@ class SendGridTest_SendGrid extends \PHPUnit_Framework_TestCase
             'Accept: application/json'
         );
 
-        $this->assertEquals($this->getProtectedPropertyValueFromObject($sg->client, 'host'), 'https://api.sendgrid.com');
-        $this->assertEquals($this->getProtectedPropertyValueFromObject($sg->client, 'headers'), $headers);
-        $this->assertEquals($this->getProtectedPropertyValueFromObject($sg->client, 'version'), '/v3');
+        $this->assertEquals($sg->client->getHost(), 'https://api.sendgrid.com');
+        $this->assertEquals($sg->client->getHeaders(), $headers);
+        $this->assertEquals($sg->client->getVersion(), '/v3');
 
         $apiKey = 'SENDGRID_API_KEY';
         $sg2 = new SendGrid($apiKey, array('host' => 'https://api.test.com'));
-        $this->assertEquals($this->getProtectedPropertyValueFromObject($sg2->client, 'host'), 'https://api.test.com');
+        $this->assertEquals($sg2->client->getHost(), 'https://api.test.com');
     }
 
     public function test_access_settings_activity_get()


### PR DESCRIPTION
Version 3.2.0 and above from the `sendgrid/php-http-client` library use improved autoloading, fixing a problem where `\SendGrid\Response` cannot be found when using a non-optimized composer installation.
When semantic versioning is applied, it is save to upgrade to newer feature releases.