### PR TITLE
added support to extend curl options

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,23 +1,29 @@
 {
-  "name": "sendgrid/sendgrid",
-  "description": "This library allows you to quickly and easily send emails through SendGrid using PHP.",
-  "version": "5.1.2",
-  "homepage": "http://github.com/sendgrid/sendgrid-php",
-  "license": "MIT",
-  "keywords": ["SendGrid", "sendgrid", "email", "send", "grid"],
-  "require": {
-    "php": ">=5.6",
-    "sendgrid/php-http-client": "~3.5"
-  },
-  "require-dev": {
-    "phpunit/phpunit": "4.*",
-    "squizlabs/php_codesniffer": "2.*"
-  },
-  "replace": {
-    "sendgrid/sendgrid-php": "*"
-  },
-  "type": "library",
-  "autoload": {
-    "files": ["lib/SendGrid.php", "lib/helpers/mail/Mail.php"]
-  }
+    "name": "sendgrid/sendgrid",
+    "description": "This library allows you to quickly and easily send emails through SendGrid using PHP.",
+    "version": "5.1.2",
+    "homepage": "http://github.com/sendgrid/sendgrid-php",
+    "license": "MIT",
+    "keywords": ["SendGrid", "sendgrid", "email", "send", "grid"],
+    "require": {
+        "php": ">=5.6",
+        "sendgrid/php-http-client": "dev-master"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "4.*",
+        "squizlabs/php_codesniffer": "2.*"
+    },
+    "replace": {
+        "sendgrid/sendgrid-php": "*"
+    },
+    "type": "library",
+    "autoload": {
+        "files": ["lib/SendGrid.php", "lib/helpers/mail/Mail.php"]
+    },
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/ninsuo/php-http-client.git"
+        }
+    ]
 }

--- a/lib/SendGrid.php
+++ b/lib/SendGrid.php
@@ -47,7 +47,23 @@ class SendGrid
             'User-Agent: sendgrid/' . $this->version . ';php',
             'Accept: application/json'
             );
-        $host = isset($options['host']) ? $options['host'] : 'https://api.sendgrid.com';
-        $this->client = new \SendGrid\Client($host, $headers, '/v3', null);
+
+        $settings = $this->getSettings($options);
+        $this->client = new \SendGrid\Client($settings['host'], $headers, '/v3', null, $settings['curlOptions']);
+    }
+
+    /**
+     * Merge default and given options to ensure existance
+     * of all settings.
+     *
+     * @param array $options
+     * @return array
+     */
+    protected function getSettings(array $options)
+    {
+        return array_merge([
+            'host' => 'https://api.sendgrid.com',
+            'curlOptions' => [],
+        ], $options);
     }
 }

--- a/test/unit/SendGridTest.php
+++ b/test/unit/SendGridTest.php
@@ -84,7 +84,7 @@ class SendGridTest_SendGrid extends \PHPUnit_Framework_TestCase
         $sg3 = new SendGrid($apiKey, array('curl' => array('foo' => 'bar')));
         $this->assertEquals(array('foo' => 'bar'), $sg3->client->getCurlOptions());
       
-        $sg4 = new SendGrid($apiKey, ['curlOptions' => [CURLOPT_PROXY => '127.0.0.1:8000']]);
+        $sg4 = new SendGrid($apiKey, ['curl' => [CURLOPT_PROXY => '127.0.0.1:8000']]);
         $this->assertEquals($sg4->client->getCurlOptions(), [10004 => '127.0.0.1:8000']);
     }
 

--- a/test/unit/SendGridTest.php
+++ b/test/unit/SendGridTest.php
@@ -85,7 +85,7 @@ class SendGridTest_SendGrid extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('foo' => 'bar'), $sg3->client->getCurlOptions());
       
         $sg4 = new SendGrid($apiKey, ['curlOptions' => [CURLOPT_PROXY => '127.0.0.1:8000']]);
-        $this->assertEquals($sg4->client->getCurlOptions(), [CURLOPT_PROXY => '127.0.0.1:8000']);
+        $this->assertEquals($sg4->client->getCurlOptions(), [10004 => '127.0.0.1:8000']);
     }
 
     public function test_access_settings_activity_get()

--- a/test/unit/SendGridTest.php
+++ b/test/unit/SendGridTest.php
@@ -80,6 +80,9 @@ class SendGridTest_SendGrid extends \PHPUnit_Framework_TestCase
         $apiKey = 'SENDGRID_API_KEY';
         $sg2 = new SendGrid($apiKey, array('host' => 'https://api.test.com'));
         $this->assertEquals($sg2->client->getHost(), 'https://api.test.com');
+
+        $sg3 = new SendGrid($apiKey, ['curlOptions' => [CURLOPT_PROXY => '127.0.0.1:8000']]);
+        $this->assertEquals($sg3->client->getCurlOptions(), [CURLOPT_PROXY => '127.0.0.1:8000']);
     }
 
     public function test_access_settings_activity_get()


### PR DESCRIPTION
This PR add a curlOptions option to merge custom parameters to curl, and add the ability to set a proxy and/or a timeout.

Should be merged after:
https://github.com/sendgrid/php-http-client/pull/11
