### PR TITLE
Typo 'user' for 'usr'

### DIFF
--- a/test/unit/SendGridTest.php
+++ b/test/unit/SendGridTest.php
@@ -41,7 +41,7 @@ class SendGridTest_SendGrid extends \PHPUnit_Framework_TestCase
                     fclose($pipes[2]);
                     proc_close($proc_grep);
                 } catch (Exception $e) {
-                    print("Error downloading the prism binary, you can try downloading directly here (https://github.com/stoplightio/prism/releases) and place in your /user/local/bin directory: " .  $e->getMessage() . "\n");
+                    print("Error downloading the prism binary, you can try downloading directly here (https://github.com/stoplightio/prism/releases) and place in your /usr/local/bin directory: " .  $e->getMessage() . "\n");
                     exit();
                 }
             } else {


### PR DESCRIPTION
As per the Node.js, Python and Ruby implementations