### PR TITLE
API level addressing of the string-only custom arg rule

### DIFF
--- a/lib/helpers/mail/Mail.php
+++ b/lib/helpers/mail/Mail.php
@@ -807,7 +807,7 @@ class Personalization implements \JsonSerializable
 
     public function addCustomArg($key, $value)
     {
-        $this->custom_args[$key] = $value;
+        $this->custom_args[$key] = (string)$value;
     }
 
     public function getCustomArgs()
@@ -1020,7 +1020,7 @@ class Mail implements \JsonSerializable
 
     public function addCustomArg($key, $value)
     {
-        $this->custom_args[$key] = $value;
+        $this->custom_args[$key] = (string)$value;
     }
 
     public function getCustomArgs()


### PR DESCRIPTION
custom args can *only* be strings per SendGrid support otherwise a 400 bad request will be returned