### PR TITLE
mail.send only accepts string custom arguments

### DIFF
--- a/lib/helpers/mail/Mail.php
+++ b/lib/helpers/mail/Mail.php
@@ -807,7 +807,8 @@ class Personalization implements \JsonSerializable
 
     public function addCustomArg($key, $value)
     {
-        $this->custom_args[$key] = $value;
+        // mail.send only accepts string custom arguments
+        $this->custom_args[$key] = (string) $value;
     }
 
     public function getCustomArgs()


### PR DESCRIPTION
When adding custom arguments that are not strings, the REST API returns "bad request".

Rather than every implementation of the API casting as string, the helper function should do this for us.