### PR TITLE
Allow passing curlOptions to the client

### DIFF
--- a/lib/SendGrid.php
+++ b/lib/SendGrid.php
@@ -38,7 +38,7 @@ class SendGrid
       * Setup the HTTP Client
       *
       * @param string $apiKey  your SendGrid API Key.
-      * @param array  $options an array of options, currently only "host" is implemented.
+      * @param array  $options an array of options, currently only "host" and "curl" are implemented.
       */
     public function __construct($apiKey, $options = array())
     {
@@ -48,6 +48,9 @@ class SendGrid
             'Accept: application/json'
             );
         $host = isset($options['host']) ? $options['host'] : 'https://api.sendgrid.com';
-        $this->client = new \SendGrid\Client($host, $headers, '/v3', null);
+
+        $curlOptions = isset($options['curl']) ? $options['curl'] : null;
+
+        $this->client = new \SendGrid\Client($host, $headers, '/v3', null, $curlOptions);
     }
 }

--- a/test/unit/SendGridTest.php
+++ b/test/unit/SendGridTest.php
@@ -80,6 +80,10 @@ class SendGridTest_SendGrid extends \PHPUnit_Framework_TestCase
         $apiKey = 'SENDGRID_API_KEY';
         $sg2 = new SendGrid($apiKey, array('host' => 'https://api.test.com'));
         $this->assertEquals($sg2->client->getHost(), 'https://api.test.com');
+
+        $apiKey = 'SENDGRID_API_KEY';
+        $sg3 = new SendGrid($apiKey, array('curl' => array('foo' => 'bar')));
+        $this->assertEquals(array('foo' => 'bar'), $sg3->client->getCurlOptions());
     }
 
     public function test_access_settings_activity_get()


### PR DESCRIPTION
In order to allow proxies and curl specific options. Should fix #345 