### PR TITLE
Relative path fix for background jobs (Issue #352)

### DIFF
--- a/scripts/s3upload.sh
+++ b/scripts/s3upload.sh
@@ -7,7 +7,7 @@ GIT_VERSION=`git rev-parse --short HEAD`
 
 rm -rf vendor composer.lock
 composer install --no-dev
-printf "<?php\nrequire 'vendor/autoload.php';\n?>" > sendgrid-php.php
+printf "<?php\nrequire __DIR__ . '/vendor/autoload.php';\n?>" > sendgrid-php.php
 cd ..
 zip -r sendgrid-php.zip sendgrid-php -x \*.git\* \*composer.json\* \*scripts\* \*test\* \*.travis.yml\*
 


### PR DESCRIPTION
if you require the sendgrid-php.php (Non-composer version) in a background process you would have relative path problems. Full path solves this problem.

