### PR TITLE
UTF8 force

### DIFF
--- a/lib/helpers/mail/Mail.php
+++ b/lib/helpers/mail/Mail.php
@@ -741,7 +741,7 @@ class Content implements \JsonSerializable
     public function __construct($type, $value)
     {
         $this->type = $type;
-        $this->value = $value;
+        $this->value = mb_convert_encoding($value, 'UTF-8', 'UTF-8');
     }
 
     public function setType($type)
@@ -756,7 +756,7 @@ class Content implements \JsonSerializable
 
     public function setValue($value)
     {
-        $this->value = $value;
+        $this->value = mb_convert_encoding($value, 'UTF-8', 'UTF-8');
     }
 
     public function getValue()
@@ -822,7 +822,7 @@ class Personalization implements \JsonSerializable
 
     public function setSubject($subject)
     {
-        $this->subject = $subject;
+        $this->subject = mb_convert_encoding($subject, 'UTF-8', 'UTF-8');
     }
 
     public function getSubject()


### PR DESCRIPTION
Proposing a force to UTF8 encoding on set for content value and message subject.  If you pass non-UTF8 into the v3 API currently it will error with no reason giving; a "null" response with zero feedback to the caller.  My "experience" is I had customer data with awkward encoding which caused a rabbit hole chase to find the core issue.  I believe there is a good solid argument that my app should have forced the encoding.  I agree with this.  However, this fix at the SDK level may save someone else the pain.  Also interested in other ways to work around it and open to feedback.