### PR TITLE
Refactoring whole library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,14 @@
   },
   "type": "library",
   "autoload": {
-    "files": ["lib/SendGrid.php", "lib/helpers/mail/Mail.php"]
+    "files": ["lib/SendGrid.php", "lib/helpers/mail/Mail.php"],
+    "psr-4": {
+      "SendGrid\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Test\\": "tests/"
+    }
   }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+         bootstrap="vendor/autoload.php"
+>
+    <testsuites>
+        <testsuite name="SendGrid Test Suites">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace SendGrid\Collection;
+
+class Collection implements \JsonSerializable
+{
+    /**
+     * @var array
+     */
+    protected $collection;
+
+    /**
+     * @param array $collection
+     */
+    public function __construct(array $collection = [])
+    {
+        $this->collection = $collection;
+    }
+
+    /**
+     * @param array $collection
+     * @return static
+     */
+    public function addMany(array $collection)
+    {
+        foreach ($collection as $object) {
+            $this->collection[] = $object;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEmpty()
+    {
+        return empty($this->collection);
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->collection;
+    }
+
+    /**
+     * @param callable $callable
+     * @return static
+     */
+    public function each(callable $callable)
+    {
+        $collection = $this->toArray();
+
+        array_walk($collection, $callable);
+
+        return $this;
+    }
+
+    /**
+     * @param callable $callable
+     * @return static
+     */
+    public function map(callable $callable)
+    {
+        return new static(array_map($callable, $this->toArray()));
+    }
+
+    /**
+     * @param callable $callable
+     * @return static
+     */
+    public function filter(callable $callable)
+    {
+        return new static(array_filter($this->toArray(), $callable));
+    }
+
+    /**
+     * @return int
+     */
+    public function count()
+    {
+        return count($this->toArray());
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * @return mixed
+     */
+    public function first()
+    {
+        return $this->collection[0];
+    }
+}

--- a/src/Collection/Exception/CollectionIsEmptyException.php
+++ b/src/Collection/Exception/CollectionIsEmptyException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace SendGrid\Collection\Exception;
+
+use SendGrid\SendGrid\Exception\SendGridException;
+
+class CollectionIsEmptyException extends SendGridException
+{
+    const ELEMENT = 'element';
+    const MESSAGE = 'Collection should contain at least one %s';
+
+    /**
+     * @var string
+     */
+    public $message;
+
+    public function __construct()
+    {
+        $this->message = sprintf(self::MESSAGE, static::ELEMENT);
+    }
+}

--- a/src/Mail/Essential/Collection/ContentCollection.php
+++ b/src/Mail/Essential/Collection/ContentCollection.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace SendGrid\Mail\Essential\Collection;
+
+use SendGrid\Collection\Collection;
+use SendGrid\Mail\Essential\Content;
+
+final class ContentCollection extends Collection
+{
+    /**
+     * @param Content $content
+     * @return $this
+     */
+    public function add(Content $content)
+    {
+        $this->collection[] = $content;
+
+        return $this;
+    }
+}

--- a/src/Mail/Essential/Collection/ToCollection.php
+++ b/src/Mail/Essential/Collection/ToCollection.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace SendGrid\Mail\Essential\Collection;
+
+use SendGrid\Mail\Essential\To;
+use SendGrid\Collection\Collection;
+
+final class ToCollection extends Collection
+{
+    /**
+     * @param To $to
+     * @return ToCollection
+     */
+    public function add(To $to)
+    {
+        $this->collection[] = $to;
+
+        return $this;
+    }
+}

--- a/src/Mail/Essential/Content.php
+++ b/src/Mail/Essential/Content.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace SendGrid\Mail\Essential;
+
+final class Content implements \JsonSerializable
+{
+    const UTF8 = 'UTF-8';
+
+    /**
+     * @var string
+     */
+    private $type;
+
+    /**
+     * @var string
+     */
+    private $value;
+
+    /**
+     * @param string $type
+     * @param string $value
+     */
+    public function __construct($type, $value)
+    {
+        $this->validateScalar($type, $value);
+        $this->type  = $type;
+        $this->value = mb_convert_encoding($value, self::UTF8, self::UTF8);
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return string
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param string $type
+     * @param string $value
+
+     * @return void
+     */
+    private function validateScalar($type, $value)
+    {
+        if (!is_string($type) || !is_string($value)) {
+            throw new \InvalidArgumentException('Arguments should be strings');
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'type'  => $this->type,
+            'value' => $this->value
+        ];
+    }
+}

--- a/src/Mail/Essential/Exception/ContentCollectionIsEmptyException.php
+++ b/src/Mail/Essential/Exception/ContentCollectionIsEmptyException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SendGrid\Mail\Essential\Exception;
+
+use SendGrid\Collection\Exception\CollectionIsEmptyException;
+
+final class ContentCollectionIsEmptyException extends CollectionIsEmptyException
+{
+    const ELEMENT = 'Content';
+}

--- a/src/Mail/Essential/Exception/ToCollectionIsEmptyException.php
+++ b/src/Mail/Essential/Exception/ToCollectionIsEmptyException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SendGrid\Mail\Essential\Exception;
+
+use SendGrid\Collection\Exception\CollectionIsEmptyException;
+
+final class ToCollectionIsEmptyException extends CollectionIsEmptyException
+{
+    const ELEMENT = 'To';
+}

--- a/src/Mail/Essential/From.php
+++ b/src/Mail/Essential/From.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SendGrid\Mail\Essential;
+
+use SendGrid\Mail\ValueObject\EmailAddress;
+
+final class From extends EmailAddress
+{
+
+}

--- a/src/Mail/Essential/To.php
+++ b/src/Mail/Essential/To.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SendGrid\Mail\Essential;
+
+use SendGrid\Mail\ValueObject\EmailAddress;
+
+final class To extends EmailAddress
+{
+
+}

--- a/src/Mail/Exception/InvalidEmailAddressException.php
+++ b/src/Mail/Exception/InvalidEmailAddressException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace SendGrid\Mail\Exception;
+
+final class InvalidEmailAddressException extends \InvalidArgumentException
+{
+
+}

--- a/src/Mail/Mail.php
+++ b/src/Mail/Mail.php
@@ -1,0 +1,811 @@
+<?php
+
+namespace SendGrid\Mail;
+
+use SendGrid\Mail\Optional\Asm;
+use SendGrid\Mail\Essential\To;
+use SendGrid\Mail\Setting\Footer;
+use SendGrid\Mail\Optional\Header;
+use SendGrid\Mail\Essential\From;
+use SendGrid\Mail\Setting\SpamCheck;
+use SendGrid\Mail\Essential\Content;
+use SendGrid\Mail\Optional\Section;
+use SendGrid\Mail\Setting\BccSettings;
+use SendGrid\Mail\Setting\SandBoxMode;
+use SendGrid\Mail\Optional\Subject;
+use SendGrid\Mail\Optional\ReplyTo;
+use SendGrid\Mail\Setting\OpenTracking;
+use SendGrid\Mail\Optional\Category;
+use SendGrid\Mail\Setting\MailSettings;
+use SendGrid\Mail\Setting\ClickTracking;
+use SendGrid\Mail\Optional\Attachment;
+use SendGrid\Mail\Essential\Collection\ToCollection;
+use SendGrid\Mail\Setting\GoogleAnalytics;
+use SendGrid\Mail\Setting\TrackingSettings;
+use SendGrid\Mail\Optional\Cc;
+use SendGrid\Mail\Optional\Bcc;
+use SendGrid\Mail\Optional\Substitution;
+use SendGrid\Mail\Setting\ByPassListManagement;
+use SendGrid\Mail\Optional\Collection\ReplyToCollection;
+use SendGrid\Mail\Setting\SubscriptionTracking;
+use SendGrid\Mail\Optional\Collection\CategoryCollection;
+use SendGrid\Mail\Optional\Collection\HeaderCollection;
+use SendGrid\Mail\Optional\Collection\SectionCollection;
+use SendGrid\Mail\Optional\CustomArgument;
+use SendGrid\Mail\Essential\Collection\ContentCollection;
+use SendGrid\Mail\Optional\Personalization;
+use SendGrid\Mail\Optional\Collection\CcCollection;
+use SendGrid\Mail\Optional\Collection\BccCollection;
+use SendGrid\Mail\Optional\Collection\AttachmentCollection;
+use SendGrid\Mail\Setting\Exception\MailSettingsIsEmptyException;
+use SendGrid\Mail\Optional\Collection\SubstitutionCollection;
+use SendGrid\Mail\Setting\Exception\TrackingSettingsIsEmptyException;
+use SendGrid\Mail\Optional\Exception\ReplyToCollectionIsEmptyException;
+use SendGrid\Mail\Optional\Exception\CategoryCollectionIsEmptyException;
+use SendGrid\Mail\Optional\Exception\HeaderCollectionIsEmptyException;
+use SendGrid\Mail\Optional\Collection\CustomArgumentCollection;
+use SendGrid\Mail\Optional\Exception\SectionCollectionIsEmptyException;
+use SendGrid\Mail\Essential\Exception\ContentCollectionIsEmptyException;
+use SendGrid\Mail\Optional\Collection\PersonalizationCollection;
+use SendGrid\Mail\Optional\Exception\AttachmentCollectionIsEmptyException;
+use SendGrid\Mail\Optional\Exception\CustomArgumentCollectionIsEmptyException;
+use SendGrid\Mail\Optional\Exception\PersonalizationCollectionIsEmptyException;
+
+final class Mail implements \JsonSerializable
+{
+    /**
+     * @var From
+     */
+    private $from;
+
+    /**
+     * @var ToCollection
+     */
+    private $tos;
+
+    /**
+     * @var Subject
+     */
+    private $subject;
+
+    /**
+     * @var ContentCollection
+     */
+    private $contents;
+
+    /**
+     * @var PersonalizationCollection
+     */
+    private $personalizations;
+
+    /**
+     * @var AttachmentCollection|null
+     */
+    private $attachments;
+
+    /**
+     * @var string|null
+     */
+    private $templateId;
+
+    /**
+     * @var ReplyToCollection|null
+     */
+    private $repliesTo;
+
+    /**
+     * @var SectionCollection|null
+     */
+    private $sections;
+
+    /**
+     * @var HeaderCollection|null
+     */
+    private $headers;
+
+    /**
+     * @var CategoryCollection|null
+     */
+    private $categories;
+
+    /**
+     * @var CustomArgumentCollection|null
+     */
+    private $customArgs;
+
+    /**
+     * @var \DateTime
+     */
+    private $sendAt;
+
+    /**
+     * @var string
+     */
+    private $batchId;
+
+    /**
+     * @var Asm|null
+     */
+    private $asm;
+
+    /**
+     * @var string|null
+     */
+    private $ipPoolName;
+
+    /**
+     * @var MailSettings|null
+     */
+    private $mailSettings;
+
+    /**
+     * @var TrackingSettings|null
+     */
+    private $trackingSettings;
+
+    /**
+     * @param From $from
+     * @param ToCollection $tos
+     * @param ContentCollection $contents
+     * @param Subject|null $subject
+     */
+    public function __construct(From $from, ToCollection $tos, ContentCollection $contents, Subject $subject = null)
+    {
+        $this->from             = $from;
+        $this->tos              = $tos;
+        $this->contents         = $contents;
+        $this->subject          = $subject;
+        $this->personalizations = new PersonalizationCollection([new Personalization($tos, $subject)]);
+    }
+
+    /**
+     * @param To $to
+     * @return Mail
+     */
+    public function addTo(To $to)
+    {
+        $this->getBasePersonalization()->addTo($to);
+
+        return $this;
+    }
+
+    /**
+     * @param ToCollection $tos
+     * @return Mail
+     */
+    public function addTos(ToCollection $tos)
+    {
+        $this->getBasePersonalization()->addTos($tos);
+
+        return $this;
+    }
+
+    /**
+     * @param Cc $cc
+     * @return Mail
+     */
+    public function addCc(Cc $cc)
+    {
+        $this->getBasePersonalization()->addCc($cc);
+
+        return $this;
+    }
+
+    /**
+     * @param CcCollection $ccs
+     * @return Mail
+     */
+    public function addCcs(CcCollection $ccs)
+    {
+        $this->getBasePersonalization()->addCcs($ccs);
+
+        return $this;
+    }
+
+    /**
+     * @param Bcc $bcc
+     * @return Mail
+     */
+    public function addBcc(Bcc $bcc)
+    {
+        $this->getBasePersonalization()->addBcc($bcc);
+
+        return $this;
+    }
+
+    /**
+     * @param BccCollection $bccs
+     * @return Mail
+     */
+    public function addBccs(BccCollection $bccs)
+    {
+        $this->getBasePersonalization()->addBccs($bccs);
+
+        return $this;
+    }
+
+    /**
+     * @param Header $header
+     * @return Mail
+     */
+    public function addHeaderToBasePersonalization(Header $header)
+    {
+        $this->getBasePersonalization()->addHeader($header);
+
+        return $this;
+    }
+
+    /**
+     * @param HeaderCollection $headers
+     * @return Mail
+     */
+    public function addHeadersToBasePersonalization(HeaderCollection $headers)
+    {
+        $this->getBasePersonalization()->addHeaders($headers);
+
+        return $this;
+    }
+
+    /**
+     * @param Substitution $substitution
+     * @return Mail
+     */
+    public function addSubstitution(Substitution $substitution)
+    {
+        $this->getBasePersonalization()->addSubstitution($substitution);
+
+        return $this;
+    }
+
+    /**
+     * @param SubstitutionCollection $substitutions
+     * @return Mail
+     */
+    public function addSubstitutions(SubstitutionCollection $substitutions)
+    {
+        $this->getBasePersonalization()->addSubstitutions($substitutions);
+
+        return $this;
+    }
+
+    /**
+     * @param CustomArgument $customArgument
+     * @return Mail
+     */
+    public function addCustomArgumentToBasePersonalization(CustomArgument $customArgument)
+    {
+        $this->getBasePersonalization()->addCustomArgument($customArgument);
+
+        return $this;
+    }
+
+    /**
+     * @param CustomArgumentCollection $customArguments
+     * @return Mail
+     */
+    public function addCustomArgumentsToBasePersonalization(CustomArgumentCollection $customArguments)
+    {
+        $this->getBasePersonalization()->addCustomArguments($customArguments);
+
+        return $this;
+    }
+
+    /**
+     * @param Personalization $personalization
+     * @return Mail
+     */
+    public function addPersonalization(Personalization $personalization)
+    {
+        $this->personalizations->add($personalization);
+
+        return $this;
+    }
+
+    /**
+     * @param PersonalizationCollection $personalizations
+     * @return Mail
+     * @throws PersonalizationCollectionIsEmptyException
+     */
+    public function addPersonalizations(PersonalizationCollection $personalizations)
+    {
+        if ($personalizations->isEmpty()) {
+            throw new PersonalizationCollectionIsEmptyException;
+        }
+        $this->personalizations->addMany($personalizations->toArray());
+
+        return $this;
+    }
+
+    /**
+     * @param Attachment $attachment
+     * @return Mail
+     */
+    public function addAttachment(Attachment $attachment)
+    {
+        $this->createAttachmentCollectionIfNull();
+        $this->attachments->add($attachment);
+
+        return $this;
+    }
+
+    /**
+     * @param AttachmentCollection $attachments
+     * @return Mail
+     * @throws AttachmentCollectionIsEmptyException
+     */
+    public function addAttachments(AttachmentCollection $attachments)
+    {
+        if ($attachments->isEmpty()) {
+            throw new AttachmentCollectionIsEmptyException;
+        }
+        $this->createAttachmentCollectionIfNull();
+        $this->attachments->addMany($attachments->toArray());
+
+        return $this;
+    }
+
+    /**
+     * @param Content $content
+     * @return Mail
+     */
+    public function addContent(Content $content)
+    {
+        $this->contents->add($content);
+
+        return $this;
+    }
+
+    /**
+     * @param ContentCollection $contents
+     * @return Mail
+     * @throws ContentCollectionIsEmptyException
+     */
+    public function addContents(ContentCollection $contents)
+    {
+        if ($contents->isEmpty()) {
+            throw new ContentCollectionIsEmptyException;
+        }
+        $this->contents->addMany($contents->toArray());
+
+        return $this;
+    }
+
+    /**
+     * @param Section $section
+     * @return Mail
+     */
+    public function addSection(Section $section)
+    {
+        $this->createSectionCollectionIfNull();
+        $this->sections->add($section);
+
+        return $this;
+    }
+
+    /**
+     * @param SectionCollection $sections
+     * @return Mail
+     * @throws SectionCollectionIsEmptyException
+     */
+    public function addSections(SectionCollection $sections)
+    {
+        if ($sections->isEmpty()) {
+            throw new SectionCollectionIsEmptyException;
+        }
+        $this->createSectionCollectionIfNull();
+        $this->sections->addMany($sections->toArray());
+
+        return $this;
+    }
+
+    /**
+     * @param Header $header
+     * @return Mail
+     */
+    public function addHeader(Header $header)
+    {
+        $this->createHeaderCollectionIfNull();
+        $this->headers->add($header);
+
+        return $this;
+    }
+
+    /**
+     * @param HeaderCollection $headers
+     * @return Mail
+     * @throws HeaderCollectionIsEmptyException
+     */
+    public function addHeaders(HeaderCollection $headers)
+    {
+        if ($headers->isEmpty()) {
+            throw new HeaderCollectionIsEmptyException;
+        }
+        $this->createHeaderCollectionIfNull();
+        $this->headers->addMany($headers->toArray());
+
+        return $this;
+    }
+
+    /**
+     * @param Category $category
+     * @return Mail
+     */
+    public function addCategory(Category $category)
+    {
+        $this->createCategoryCollectionIfNull();
+        $this->categories->add($category);
+
+        return $this;
+    }
+
+    /**
+     * @param CategoryCollection $categories
+     * @return Mail
+     * @throws CategoryCollectionIsEmptyException
+     */
+    public function addCategories(CategoryCollection $categories)
+    {
+        if ($categories->isEmpty()) {
+            throw new CategoryCollectionIsEmptyException;
+        }
+        $this->createCategoryCollectionIfNull();
+        $this->categories->addMany($categories->toArray());
+
+        return $this;
+    }
+
+    /**
+     * @param CustomArgument $customArgument
+     * @return Mail
+     */
+    public function addCustomArgument(CustomArgument $customArgument)
+    {
+        $this->createCustomArgumentCollectionIfNull();
+        $this->customArgs->add($customArgument);
+
+        return $this;
+    }
+
+    /**
+     * @param CustomArgumentCollection $customArguments
+     * @return Mail
+     * @throws CustomArgumentCollectionIsEmptyException
+     */
+    public function addCustomArguments(CustomArgumentCollection $customArguments)
+    {
+        if ($customArguments->isEmpty()) {
+            throw new CustomArgumentCollectionIsEmptyException;
+        }
+        $this->createCustomArgumentCollectionIfNull();
+        $this->customArgs->addMany($customArguments->toArray());
+
+        return $this;
+    }
+
+    /**
+     * @param Asm $asm
+     * @return Mail
+     */
+    public function addAsm(Asm $asm)
+    {
+        $this->asm = $asm;
+
+        return $this;
+    }
+
+    /**
+     * @param $ipPoolName
+     * @return Mail
+     */
+    public function addIpPoolName($ipPoolName)
+    {
+        $this->ipPoolName = $ipPoolName;
+
+        return $this;
+    }
+
+    /**
+     * @param MailSettings $mailSettings
+     * @return Mail
+     * @throws MailSettingsIsEmptyException
+     */
+    public function addMailSettings(MailSettings $mailSettings)
+    {
+        if ($mailSettings->isEmpty()) {
+            throw new MailSettingsIsEmptyException;
+        }
+        $this->mailSettings = $mailSettings;
+
+        return $this;
+    }
+
+    /**
+     * @param BccSettings $bccSettings
+     * @return Mail
+     */
+    public function addBccSettings(BccSettings $bccSettings)
+    {
+        $this->createMailSettingsIfNull();
+        $this->mailSettings->addBcc($bccSettings);
+
+        return $this;
+    }
+
+    /**
+     * @param ByPassListManagement $byPassListManagement
+     * @return Mail
+     */
+    public function addByPassListManagement(ByPassListManagement $byPassListManagement)
+    {
+        $this->createMailSettingsIfNull();
+        $this->mailSettings->addByPassListManagement($byPassListManagement);
+
+        return $this;
+    }
+
+    /**
+     * @param Footer $footer
+     * @return Mail
+     */
+    public function addFooter(Footer $footer)
+    {
+        $this->createMailSettingsIfNull();
+        $this->mailSettings->addFooter($footer);
+
+        return $this;
+    }
+
+    /**
+     * @param SandBoxMode $sandBoxMode
+     * @return Mail
+     */
+    public function addSandBoxMode(SandBoxMode $sandBoxMode)
+    {
+        $this->createMailSettingsIfNull();
+        $this->mailSettings->addSandBoxMode($sandBoxMode);
+
+        return $this;
+    }
+
+    /**
+     * @param SpamCheck $spamCheck
+     * @return Mail
+     */
+    public function addSpamCheck(SpamCheck $spamCheck)
+    {
+        $this->createMailSettingsIfNull();
+        $this->mailSettings->addSpamCheck($spamCheck);
+
+        return $this;
+    }
+
+    /**
+     * @param TrackingSettings $trackingSettings
+     * @return Mail
+     * @throws TrackingSettingsIsEmptyException
+     */
+    public function addTrackingSettings(TrackingSettings $trackingSettings)
+    {
+        if ($trackingSettings->isEmpty()) {
+            throw new TrackingSettingsIsEmptyException;
+        }
+        $this->trackingSettings = $trackingSettings;
+
+        return $this;
+    }
+
+    /**
+     * @param ClickTracking $clickTracking
+     * @return Mail
+     */
+    public function addClickTracking(ClickTracking $clickTracking)
+    {
+        $this->createTrackingSettingsIfNull();
+        $this->trackingSettings->addClickTracking($clickTracking);
+
+        return $this;
+    }
+
+    /**
+     * @param OpenTracking $openTracking
+     * @return Mail
+     */
+    public function addOpenTracking(OpenTracking $openTracking)
+    {
+        $this->createTrackingSettingsIfNull();
+        $this->trackingSettings->addOpenTracking($openTracking);
+
+        return $this;
+    }
+
+    /**
+     * @param SubscriptionTracking $subscriptionTracking
+     * @return Mail
+     */
+    public function addSubscriptionTracking(SubscriptionTracking $subscriptionTracking)
+    {
+        $this->createTrackingSettingsIfNull();
+        $this->trackingSettings->addSubscriptionTracking($subscriptionTracking);
+
+        return $this;
+    }
+
+    /**
+     * @param GoogleAnalytics $googleAnalytics
+     * @return Mail
+     */
+    public function addGoogleAnalytics(GoogleAnalytics $googleAnalytics)
+    {
+        $this->createTrackingSettingsIfNull();
+        $this->trackingSettings->addGoogleAnalytics($googleAnalytics);
+
+        return $this;
+    }
+
+    /**
+     * @param ReplyTo $replyTo
+     * @return Mail
+     */
+    public function addReplyTo(ReplyTo $replyTo)
+    {
+        $this->createReplyToCollectionIfNull();
+        $this->repliesTo->add($replyTo);
+
+        return $this;
+    }
+
+    /**
+     * @param ReplyToCollection $repliesTo
+     * @return Mail
+     * @throws ReplyToCollectionIsEmptyException
+     */
+    public function addRepliesTo(ReplyToCollection $repliesTo)
+    {
+        if ($repliesTo->isEmpty()) {
+            throw new ReplyToCollectionIsEmptyException;
+        }
+        $this->createReplyToCollectionIfNull();
+        $this->repliesTo->addMany($repliesTo->toArray());
+
+        return $this;
+    }
+
+    /**
+     * @param string $templateId
+     * @throws \InvalidArgumentException
+     * @return Mail
+     */
+    public function addTemplateId($templateId)
+    {
+        if (!is_string($templateId)) {
+            throw new \InvalidArgumentException('template id must be a string');
+        }
+        $this->templateId = $templateId;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    private function getProperties()
+    {
+        return [
+            'from'              => $this->from,
+            'personalizations'  => $this->personalizations,
+            'content'           => $this->contents,
+            'subject'           => $this->subject,
+            'attachments'       => $this->attachments,
+            'template_id'       => $this->templateId,
+            'sections'          => $this->sections,
+            'headers'           => $this->headers,
+            'categories'        => $this->categories,
+            'custom_args'       => $this->customArgs,
+            'send_at'           => $this->sendAt,
+            'batch_id'          => $this->batchId,
+            'asm'               => $this->asm,
+            'ip_pool_name'      => $this->ipPoolName,
+            'mail_settings'     => $this->mailSettings,
+            'tracking_settings' => $this->trackingSettings,
+            'reply_to'          => $this->repliesTo
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return array_filter($this->getProperties(), function ($value) {
+            return $value !== null;
+        });
+    }
+
+    /**
+     * @return Personalization
+     */
+    private function getBasePersonalization()
+    {
+        return $this->personalizations->first();
+    }
+
+    /**
+     * @return void
+     */
+    private function createMailSettingsIfNull()
+    {
+        if (null === $this->mailSettings) {
+            $this->mailSettings = new MailSettings;
+        }
+    }
+
+    /**
+     * @return void
+     */
+    private function createAttachmentCollectionIfNull()
+    {
+        if (null === $this->attachments) {
+            $this->attachments = new AttachmentCollection;
+        }
+    }
+
+    /**
+     * @return void
+     */
+    private function createSectionCollectionIfNull()
+    {
+        if (null === $this->sections) {
+            $this->sections = new SectionCollection;
+        }
+    }
+
+    /**
+     * @return void
+     */
+    private function createHeaderCollectionIfNull()
+    {
+        if (null === $this->headers) {
+            $this->headers = new HeaderCollection;
+        }
+    }
+
+    /**
+     * @return void
+     */
+    private function createCategoryCollectionIfNull()
+    {
+        if (null === $this->categories) {
+            $this->categories = new CategoryCollection;
+        }
+    }
+
+    /**
+     * @return void
+     */
+    private function createCustomArgumentCollectionIfNull()
+    {
+        if (null === $this->customArgs) {
+            $this->customArgs = new CustomArgumentCollection;
+        }
+    }
+
+    /**
+     * @return void
+     */
+    private function createTrackingSettingsIfNull()
+    {
+        if (null === $this->trackingSettings) {
+            $this->trackingSettings = new TrackingSettings;
+        }
+    }
+
+    /**
+     * @return void
+     */
+    private function createReplyToCollectionIfNull()
+    {
+        if (null === $this->repliesTo) {
+            $this->repliesTo = new ReplyToCollection;
+        }
+    }
+}

--- a/src/Mail/Optional/Asm.php
+++ b/src/Mail/Optional/Asm.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace SendGrid\Mail\Optional;
+
+final class Asm implements \JsonSerializable
+{
+    /**
+     * @var int
+     */
+    private $id;
+
+    /**
+     * @var array
+     */
+    private $groups;
+
+    /**
+     * @param int $id
+     * @param array $groups
+     */
+    public function __construct($id, array $groups)
+    {
+        $this->validateScalar($id);
+        $this->id     = $id;
+        $this->groups = $groups;
+    }
+
+    /**
+     * @param $id
+     */
+    private function validateScalar($id)
+    {
+        if (!is_int($id)) {
+            throw new \InvalidArgumentException('Argument must be integer');
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'group_id'          => $this->id,
+            'groups_to_display' => $this->groups
+        ];
+    }
+}

--- a/src/Mail/Optional/Attachment.php
+++ b/src/Mail/Optional/Attachment.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace SendGrid\Mail\Optional;
+
+final class Attachment implements \JsonSerializable
+{
+    /**
+     * @var string
+     */
+    private $content;
+
+    /**
+     * @var string
+     */
+    private $type;
+
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var string|null
+     */
+    private $disposition;
+
+    /**
+     * @var string|null
+     */
+    private $id;
+
+    /**
+     * @param string $content
+     * @param string $type
+     * @param string $name
+     * @param string|null $disposition
+     * @param string|null $id
+     */
+    public function __construct($content, $type, $name, $disposition = null, $id = null)
+    {
+        $this->validateScalar($content, $type, $name, $disposition, $id);
+        $this->content     = $content;
+        $this->type        = $type;
+        $this->name        = $name;
+        $this->disposition = $disposition;
+        $this->id          = $id;
+    }
+
+    /**
+     * @param string $content
+     * @param string $type
+     * @param string $name
+     * @param string $disposition
+     * @param string $id
+     */
+    private function validateScalar($content, $type, $name, $disposition, $id)
+    {
+        if (!is_string($content) ||
+            !is_string($type) ||
+            !is_string($name) ||
+            null !== $disposition && !is_string($disposition) ||
+            null !== $id && !is_string($id)
+        ) {
+            throw new \InvalidArgumentException('Arguments should be strings');
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $baseProperties = [
+            'content'     => $this->content,
+            'type'        => $this->type,
+            'filename'    => $this->name,
+            'disposition' => $this->disposition
+        ];
+
+        if (null !== $this->id) {
+            $baseProperties['content_id'] = $this->id;
+        }
+        return $baseProperties;
+    }
+}

--- a/src/Mail/Optional/Bcc.php
+++ b/src/Mail/Optional/Bcc.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SendGrid\Mail\Optional;
+
+use SendGrid\Mail\ValueObject\EmailAddress;
+
+final class Bcc extends EmailAddress
+{
+
+}

--- a/src/Mail/Optional/Category.php
+++ b/src/Mail/Optional/Category.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace SendGrid\Mail\Optional;
+
+final class Category implements \JsonSerializable
+{
+    /**
+     * @var string
+     */
+    private $value;
+
+    /**
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->validateScalar($value);
+        $this->value = $value;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @return string
+     */
+    public function jsonSerialize()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param $value
+     */
+    private function validateScalar($value)
+    {
+        if (!is_string($value)) {
+            throw new \InvalidArgumentException('Argument must be string');
+        }
+    }
+}

--- a/src/Mail/Optional/Cc.php
+++ b/src/Mail/Optional/Cc.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SendGrid\Mail\Optional;
+
+use SendGrid\Mail\ValueObject\EmailAddress;
+
+final class Cc extends EmailAddress
+{
+
+}

--- a/src/Mail/Optional/Collection/AttachmentCollection.php
+++ b/src/Mail/Optional/Collection/AttachmentCollection.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace SendGrid\Mail\Optional\Collection;
+
+use SendGrid\Collection\Collection;
+use SendGrid\Mail\Optional\Attachment;
+
+final class AttachmentCollection extends Collection
+{
+    /**
+     * @param Attachment $attachment
+     */
+    public function add(Attachment $attachment)
+    {
+        $this->collection[] = $attachment;
+    }
+}

--- a/src/Mail/Optional/Collection/BccCollection.php
+++ b/src/Mail/Optional/Collection/BccCollection.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace SendGrid\Mail\Optional\Collection;
+
+use SendGrid\Collection\Collection;
+use SendGrid\Mail\Optional\Bcc;
+
+final class BccCollection extends Collection
+{
+    /**
+     * @param Bcc $bcc
+     * @return BccCollection
+     */
+    public function add(Bcc $bcc)
+    {
+        $this->collection[] = $bcc;
+
+        return $this;
+    }
+}

--- a/src/Mail/Optional/Collection/CategoryCollection.php
+++ b/src/Mail/Optional/Collection/CategoryCollection.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace SendGrid\Mail\Optional\Collection;
+
+use SendGrid\Collection\Collection;
+use SendGrid\Mail\Optional\Category;
+
+final class CategoryCollection extends Collection
+{
+    /**
+     * @param Category $category
+     * @return $this
+     */
+    public function add(Category $category)
+    {
+        $this->collection[] = $category;
+
+        return $this;
+    }
+}

--- a/src/Mail/Optional/Collection/CcCollection.php
+++ b/src/Mail/Optional/Collection/CcCollection.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace SendGrid\Mail\Optional\Collection;
+
+use SendGrid\Mail\Optional\Cc;
+use SendGrid\Collection\Collection;
+
+final class CcCollection extends Collection
+{
+    /**
+     * @param Cc $cc
+     * @return CcCollection
+     */
+    public function add(Cc $cc)
+    {
+        $this->collection[] = $cc;
+
+        return $this;
+    }
+}

--- a/src/Mail/Optional/Collection/CustomArgumentCollection.php
+++ b/src/Mail/Optional/Collection/CustomArgumentCollection.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace SendGrid\Mail\Optional\Collection;
+
+use SendGrid\Collection\Collection;
+use SendGrid\Mail\Optional\CustomArgument;
+
+final class CustomArgumentCollection extends Collection
+{
+    /**
+     * @param CustomArgument $customArgument
+     * @return CustomArgumentCollection
+     */
+    public function add(CustomArgument $customArgument)
+    {
+        $this->collection[] = $customArgument;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $array = [];
+
+        $this->each(function (CustomArgument $customArgument) use (&$array) {
+            $array[$customArgument->getKey()] = $customArgument->getValue();
+        });
+
+        return $array;
+    }
+}

--- a/src/Mail/Optional/Collection/HeaderCollection.php
+++ b/src/Mail/Optional/Collection/HeaderCollection.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace SendGrid\Mail\Optional\Collection;
+
+use SendGrid\Mail\Optional\Header;
+use SendGrid\Collection\Collection;
+
+final class HeaderCollection extends Collection
+{
+    /**
+     * @param Header $header
+     * @return HeaderCollection
+     */
+    public function add(Header $header)
+    {
+        $this->collection[] = $header;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $array = [];
+
+        $this->each(function (Header $header) use (&$array) {
+            $array[$header->getKey()] = $header->getValue();
+        });
+
+        return $array;
+    }
+}

--- a/src/Mail/Optional/Collection/PersonalizationCollection.php
+++ b/src/Mail/Optional/Collection/PersonalizationCollection.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace SendGrid\Mail\Optional\Collection;
+
+use SendGrid\Collection\Collection;
+use SendGrid\Mail\Optional\Personalization;
+
+final class PersonalizationCollection extends Collection
+{
+    /**
+     * @param Personalization $personalization
+     * @return $this
+     */
+    public function add(Personalization $personalization)
+    {
+        $this->collection[] = $personalization;
+
+        return $this;
+    }
+}

--- a/src/Mail/Optional/Collection/ReplyToCollection.php
+++ b/src/Mail/Optional/Collection/ReplyToCollection.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace SendGrid\Mail\Optional\Collection;
+
+use SendGrid\Mail\Optional\ReplyTo;
+use SendGrid\Collection\Collection;
+
+final class ReplyToCollection extends Collection
+{
+    /**
+     * @param ReplyTo $replyTo
+     * @return ReplyToCollection
+     */
+    public function add(ReplyTo $replyTo)
+    {
+        $this->collection[] = $replyTo;
+
+        return $this;
+    }
+}

--- a/src/Mail/Optional/Collection/SectionCollection.php
+++ b/src/Mail/Optional/Collection/SectionCollection.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace SendGrid\Mail\Optional\Collection;
+
+use SendGrid\Collection\Collection;
+use SendGrid\Mail\Optional\Section;
+
+final class SectionCollection extends Collection
+{
+    /**
+     * @param Section $section
+     * @return $this
+     */
+    public function add(Section $section)
+    {
+        $this->collection[] = $section;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $array = [];
+
+        $this->each(function (Section $customArgument) use (&$array) {
+            $array[$customArgument->getKey()] = $customArgument->getValue();
+        });
+
+        return $array;
+    }
+}

--- a/src/Mail/Optional/Collection/SubstitutionCollection.php
+++ b/src/Mail/Optional/Collection/SubstitutionCollection.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace SendGrid\Mail\Optional\Collection;
+
+use SendGrid\Collection\Collection;
+use SendGrid\Mail\Optional\Substitution;
+
+final class SubstitutionCollection extends Collection
+{
+    /**
+     * @param Substitution $substitution
+     * @return SubstitutionCollection
+     */
+    public function addSubstitution(Substitution $substitution)
+    {
+        $this->collection[] = $substitution;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $array = [];
+
+        $this->each(function (Substitution $header) use (&$array) {
+            $array[$header->getKey()] = $header->getValue();
+        });
+
+        return $array;
+    }
+}

--- a/src/Mail/Optional/CustomArgument.php
+++ b/src/Mail/Optional/CustomArgument.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace SendGrid\Mail\Optional;
+
+final class CustomArgument implements \JsonSerializable
+{
+    /**
+     * @var string
+     */
+    private $key;
+
+    /**
+     * @var string
+     */
+    private $value;
+
+    /**
+     * @param string $key
+     * @param string $value
+     */
+    public function __construct($key, $value)
+    {
+        $this->validateScalar($key, $value);
+        $this->key   = $key;
+        $this->value = $value;
+    }
+
+    /**
+     * @return string
+     */
+    public function getKey()
+    {
+        return $this->key;
+    }
+
+    /**
+     * @return string
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            $this->key => $this->value
+        ];
+    }
+
+    /**
+     * @param $key
+     * @param $value
+     */
+    private function validateScalar($key, $value)
+    {
+        if (!is_string($key) || !is_string($value)) {
+            throw new \InvalidArgumentException('Arguments must be string');
+        }
+    }
+}

--- a/src/Mail/Optional/Exception/AttachmentCollectionIsEmptyException.php
+++ b/src/Mail/Optional/Exception/AttachmentCollectionIsEmptyException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SendGrid\Mail\Optional\Exception;
+
+use SendGrid\Collection\Exception\CollectionIsEmptyException;
+
+final class AttachmentCollectionIsEmptyException extends CollectionIsEmptyException
+{
+    const ELEMENT = 'Attachment';
+}

--- a/src/Mail/Optional/Exception/BccCollectionIsEmptyException.php
+++ b/src/Mail/Optional/Exception/BccCollectionIsEmptyException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SendGrid\Mail\Optional\Exception;
+
+use SendGrid\Collection\Exception\CollectionIsEmptyException;
+
+final class BccCollectionIsEmptyException extends CollectionIsEmptyException
+{
+    const ELEMENT = 'Bcc';
+}

--- a/src/Mail/Optional/Exception/CategoryCollectionIsEmptyException.php
+++ b/src/Mail/Optional/Exception/CategoryCollectionIsEmptyException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SendGrid\Mail\Optional\Exception;
+
+use SendGrid\Collection\Exception\CollectionIsEmptyException;
+
+final class CategoryCollectionIsEmptyException extends CollectionIsEmptyException
+{
+    const ELEMENT = 'Category';
+}

--- a/src/Mail/Optional/Exception/CcCollectionIsEmptyException.php
+++ b/src/Mail/Optional/Exception/CcCollectionIsEmptyException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SendGrid\Mail\Optional\Exception;
+
+use SendGrid\Collection\Exception\CollectionIsEmptyException;
+
+final class CcCollectionIsEmptyException extends CollectionIsEmptyException
+{
+    const ELEMENT = 'Cc';
+}

--- a/src/Mail/Optional/Exception/CustomArgumentCollectionIsEmptyException.php
+++ b/src/Mail/Optional/Exception/CustomArgumentCollectionIsEmptyException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SendGrid\Mail\Optional\Exception;
+
+use SendGrid\Collection\Exception\CollectionIsEmptyException;
+
+final class CustomArgumentCollectionIsEmptyException extends CollectionIsEmptyException
+{
+    const ELEMENT = 'Custom Argument';
+}

--- a/src/Mail/Optional/Exception/HeaderCollectionIsEmptyException.php
+++ b/src/Mail/Optional/Exception/HeaderCollectionIsEmptyException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SendGrid\Mail\Optional\Exception;
+
+use SendGrid\Collection\Exception\CollectionIsEmptyException;
+
+final class HeaderCollectionIsEmptyException extends CollectionIsEmptyException
+{
+    const ELEMENT = 'Header';
+}

--- a/src/Mail/Optional/Exception/PersonalizationCollectionIsEmptyException.php
+++ b/src/Mail/Optional/Exception/PersonalizationCollectionIsEmptyException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SendGrid\Mail\Optional\Exception;
+
+use SendGrid\Collection\Exception\CollectionIsEmptyException;
+
+final class PersonalizationCollectionIsEmptyException extends CollectionIsEmptyException
+{
+    const ELEMENT = 'Personalization';
+}

--- a/src/Mail/Optional/Exception/ReplyToCollectionIsEmptyException.php
+++ b/src/Mail/Optional/Exception/ReplyToCollectionIsEmptyException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SendGrid\Mail\Optional\Exception;
+
+use SendGrid\Collection\Exception\CollectionIsEmptyException;
+
+final class ReplyToCollectionIsEmptyException extends CollectionIsEmptyException
+{
+    const ELEMENT = 'Reply to';
+}

--- a/src/Mail/Optional/Exception/SectionCollectionIsEmptyException.php
+++ b/src/Mail/Optional/Exception/SectionCollectionIsEmptyException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SendGrid\Mail\Optional\Exception;
+
+use SendGrid\Collection\Exception\CollectionIsEmptyException;
+
+final class SectionCollectionIsEmptyException extends CollectionIsEmptyException
+{
+    const ELEMENT = 'Section';
+}

--- a/src/Mail/Optional/Exception/SubstitutionCollectionIsEmptyException.php
+++ b/src/Mail/Optional/Exception/SubstitutionCollectionIsEmptyException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SendGrid\Mail\Optional\Exception;
+
+use SendGrid\Collection\Exception\CollectionIsEmptyException;
+
+final class SubstitutionCollectionIsEmptyException extends CollectionIsEmptyException
+{
+    const ELEMENT = 'Substitution';
+}

--- a/src/Mail/Optional/Header.php
+++ b/src/Mail/Optional/Header.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace SendGrid\Mail\Optional;
+
+final class Header implements \JsonSerializable
+{
+    /**
+     * @var string
+     */
+    private $key;
+
+    /**
+     * @var string
+     */
+    private $value;
+
+    /**
+     * @param string $key
+     * @param string $value
+     */
+    public function __construct($key, $value)
+    {
+        $this->validateScalar($key, $value);
+        $this->key   = $key;
+        $this->value = $value;
+    }
+
+    /**
+     * @return string
+     */
+    public function getKey()
+    {
+        return $this->key;
+    }
+
+    /**
+     * @return string
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param $key
+     * @param $value
+     */
+    private function validateScalar($key, $value)
+    {
+        if (!is_string($key) || !is_string($value)) {
+            throw new \InvalidArgumentException('Arguments must be string');
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            $this->key => $this->value
+        ];
+    }
+}

--- a/src/Mail/Optional/Personalization.php
+++ b/src/Mail/Optional/Personalization.php
@@ -1,0 +1,309 @@
+<?php
+
+namespace SendGrid\Mail\Optional;
+
+use SendGrid\Mail\Essential\To;
+use SendGrid\Mail\Optional\Collection\CcCollection;
+use SendGrid\Mail\Optional\Collection\BccCollection;
+use SendGrid\Mail\Essential\Collection\ToCollection;
+use SendGrid\Mail\Optional\Collection\HeaderCollection;
+use SendGrid\Mail\Optional\Collection\SubstitutionCollection;
+use SendGrid\Mail\Optional\Collection\CustomArgumentCollection;
+use SendGrid\Mail\Optional\Exception\CcCollectionIsEmptyException;
+use SendGrid\Mail\Optional\Exception\BccCollectionIsEmptyException;
+use SendGrid\Mail\Essential\Exception\ToCollectionIsEmptyException;
+use SendGrid\Mail\Optional\Exception\HeaderCollectionIsEmptyException;
+use SendGrid\Mail\Optional\Exception\SubstitutionCollectionIsEmptyException;
+use SendGrid\Mail\Optional\Exception\CustomArgumentCollectionIsEmptyException;
+
+final class Personalization implements \JsonSerializable
+{
+    /**
+     * @var ToCollection
+     */
+    private $tos;
+
+    /**
+     * @var Subject|null
+     */
+    private $subject;
+
+    /**
+     * @var CcCollection|null
+     */
+    private $ccs;
+
+    /**
+     * @var BccCollection|null
+     */
+    private $bccs;
+
+    /**
+     * @var HeaderCollection|null
+     */
+    private $headers;
+
+    /**
+     * @var SubstitutionCollection|null
+     */
+    private $substitutions;
+
+    /**
+     * @var CustomArgumentCollection|null
+     */
+    private $customArguments;
+
+    /**
+     * @var \DateTime
+     */
+    private $sendAt;
+
+    /**
+     * @param ToCollection $tos
+     * @param Subject $subject
+     * @param CcCollection|null $ccs
+     * @param BccCollection|null $bccs
+     * @param HeaderCollection|null $headers
+     * @param SubstitutionCollection|null $substitutions
+     * @param CustomArgumentCollection|null $customArguments
+     */
+    public function __construct(
+        ToCollection $tos,
+        Subject $subject = null,
+        CcCollection $ccs = null,
+        BccCollection $bccs = null,
+        HeaderCollection $headers = null,
+        SubstitutionCollection $substitutions = null,
+        CustomArgumentCollection $customArguments = null
+    ) {
+        $this->tos             = $tos;
+        $this->subject         = $subject;
+        $this->ccs             = $ccs;
+        $this->bccs            = $bccs;
+        $this->headers         = $headers;
+        $this->substitutions   = $substitutions;
+        $this->customArguments = $customArguments;
+        $this->sendAt          = new \DateTime;
+    }
+
+    /**
+     * @param To $to
+     * @return Personalization
+     */
+    public function addTo(To $to)
+    {
+        $this->tos->add($to);
+
+        return $this;
+    }
+
+    /**
+     * @param ToCollection $collection
+     * @return Personalization
+     * @throws ToCollectionIsEmptyException
+     */
+    public function addTos(ToCollection $collection)
+    {
+        if ($collection->isEmpty()) {
+            throw new ToCollectionIsEmptyException;
+        }
+        $this->tos->addMany($collection->toArray());
+
+        return $this;
+    }
+
+    /**
+     * @param Cc $cc
+     * @return Personalization
+     */
+    public function addCc(Cc $cc)
+    {
+        if (null === $this->ccs) {
+            $this->ccs = new CcCollection;
+        }
+        $this->ccs->add($cc);
+
+        return $this;
+    }
+
+    /**
+     * @param CcCollection $collection
+     * @return Personalization
+     * @throws CcCollectionIsEmptyException
+     */
+    public function addCcs(CcCollection $collection)
+    {
+        if ($collection->isEmpty()) {
+            throw new CcCollectionIsEmptyException();
+        }
+        if (null === $this->ccs) {
+            $this->ccs = new CcCollection;
+        }
+        $this->ccs->addMany($collection->toArray());
+
+        return $this;
+    }
+
+    /**
+     * @param Bcc $bcc
+     * @return Personalization
+     */
+    public function addBcc(Bcc $bcc)
+    {
+        if (null === $this->bccs) {
+            $this->bccs = new BccCollection;
+        }
+        $this->bccs->add($bcc);
+
+        return $this;
+    }
+
+    /**
+     * @param BccCollection $collection
+     * @return Personalization
+     * @throws BccCollectionIsEmptyException
+     */
+    public function addBccs(BccCollection $collection)
+    {
+        if ($collection->isEmpty()) {
+            throw new BccCollectionIsEmptyException;
+        }
+        if (null === $this->bccs) {
+            $this->bccs = new BccCollection;
+        }
+        $this->bccs->addMany($collection->toArray());
+
+        return $this;
+    }
+
+    /**
+     * @param Header $header
+     * @return Personalization
+     */
+    public function addHeader(Header $header)
+    {
+        if (null === $this->headers) {
+            $this->headers = new HeaderCollection;
+        }
+        $this->headers->add($header);
+
+        return $this;
+    }
+
+    /**
+     * @param HeaderCollection $collection
+     * @return Personalization
+     * @throws HeaderCollectionIsEmptyException
+     */
+    public function addHeaders(HeaderCollection $collection)
+    {
+        if ($collection->isEmpty()) {
+            throw new HeaderCollectionIsEmptyException;
+        }
+        if (null === $this->headers) {
+            $this->headers = new HeaderCollection;
+        }
+        $this->headers->addMany($collection->toArray());
+
+        return $this;
+    }
+
+    /**
+     * @param Substitution $substitution
+     * @return Personalization
+     */
+    public function addSubstitution(Substitution $substitution)
+    {
+        if (null === $this->substitutions) {
+            $this->substitutions = new SubstitutionCollection;
+        }
+        $this->substitutions->addSubstitution($substitution);
+
+        return $this;
+    }
+
+    /**
+     * @param SubstitutionCollection $collection
+     * @return Personalization
+     * @throws SubstitutionCollectionIsEmptyException
+     */
+    public function addSubstitutions(SubstitutionCollection $collection)
+    {
+        if ($collection->isEmpty()) {
+            throw new SubstitutionCollectionIsEmptyException;
+        }
+        if (null === $this->substitutions) {
+            $this->substitutions = new SubstitutionCollection;
+        }
+        $this->substitutions->addMany($collection->toArray());
+
+        return $this;
+    }
+
+    /**
+     * @param CustomArgument $customArgument
+     * @return Personalization
+     */
+    public function addCustomArgument(CustomArgument $customArgument)
+    {
+        if (null === $this->customArguments) {
+            $this->customArguments = new CustomArgumentCollection;
+        }
+        $this->customArguments->add($customArgument);
+
+        return $this;
+    }
+
+    /**
+     * @param CustomArgumentCollection $collection
+     * @return Personalization
+     * @throws CustomArgumentCollectionIsEmptyException
+     */
+    public function addCustomArguments(CustomArgumentCollection $collection)
+    {
+        if ($collection->isEmpty()) {
+            throw new CustomArgumentCollectionIsEmptyException;
+        }
+        if (null === $this->customArguments) {
+            $this->customArguments = new CustomArgumentCollection;
+        }
+        $this->customArguments->addMany($collection->toArray());
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getSendAt()
+    {
+        return strtotime($this->sendAt->format('Y-m-d H:i:s'));
+    }
+
+    /**
+     * @return array
+     */
+    private function getProperties()
+    {
+        return [
+            'to'            => $this->tos,
+            'cc'            => $this->ccs,
+            'bcc'           => $this->bccs,
+            'subject'       => $this->subject,
+            'headers'       => $this->headers,
+            'substitutions' => $this->substitutions,
+            'custom_args'   => $this->customArguments,
+            'send_at'       => $this->getSendAt()
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return array_filter($this->getProperties(), function ($value) {
+            return $value !== null;
+        });
+    }
+}

--- a/src/Mail/Optional/ReplyTo.php
+++ b/src/Mail/Optional/ReplyTo.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SendGrid\Mail\Optional;
+
+use SendGrid\Mail\ValueObject\EmailAddress;
+
+final class ReplyTo extends EmailAddress
+{
+
+}

--- a/src/Mail/Optional/Section.php
+++ b/src/Mail/Optional/Section.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace SendGrid\Mail\Optional;
+
+final class Section implements \JsonSerializable
+{
+    /**
+     * @var string
+     */
+    private $key;
+
+    /**
+     * @var string
+     */
+    private $value;
+
+    /**
+     * @param string $key
+     * @param string $value
+     */
+    public function __construct($key, $value)
+    {
+        $this->validateScalar($key, $value);
+        $this->key   = $key;
+        $this->value = $value;
+    }
+
+    /**
+     * @return string
+     */
+    public function getKey()
+    {
+        return $this->key;
+    }
+
+    /**
+     * @return string
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            $this->key => $this->value
+        ];
+    }
+
+    /**
+     * @param string $key
+     * @param string $value
+     */
+    private function validateScalar($key, $value)
+    {
+        if (!is_string($key) || !is_string($value)) {
+            throw new \InvalidArgumentException('Arguments must be string');
+        }
+    }
+}

--- a/src/Mail/Optional/Subject.php
+++ b/src/Mail/Optional/Subject.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace SendGrid\Mail\Optional;
+
+final class Subject implements \JsonSerializable
+{
+    /**
+     * @var string
+     */
+    private $value;
+
+    /**
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->validateScalar($value);
+        $this->value = $value;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param $value
+     * @return void
+     */
+    private function validateScalar($value)
+    {
+        if (!is_string($value)) {
+            throw new \InvalidArgumentException('Argument must be string');
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function jsonSerialize()
+    {
+        return $this->value;
+    }
+}

--- a/src/Mail/Optional/Substitution.php
+++ b/src/Mail/Optional/Substitution.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace SendGrid\Mail\Optional;
+
+final class Substitution implements \JsonSerializable
+{
+    /**
+     * @var string
+     */
+    private $key;
+
+    /**
+     * @var string
+     */
+    private $value;
+
+    /**
+     * @param string $key
+     * @param string $value
+     */
+    public function __construct($key, $value)
+    {
+        $this->validateScalar($key, $value);
+        $this->key   = $key;
+        $this->value = $value;
+    }
+
+    /**
+     * @return string
+     */
+    public function getKey()
+    {
+        return $this->key;
+    }
+
+    /**
+     * @return string
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            $this->key => $this->value
+        ];
+    }
+
+    /**
+     * @param string $key
+     * @param string $value
+     * @return void
+     */
+    private function validateScalar($key, $value)
+    {
+        if (!is_string($key) || !is_string($value)) {
+            throw new \InvalidArgumentException('Arguments must be string');
+        }
+    }
+}

--- a/src/Mail/Setting/BccSettings.php
+++ b/src/Mail/Setting/BccSettings.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace SendGrid\Mail\Setting;
+
+use SendGrid\Mail\ValueObject\EmailAddress;
+
+final class BccSettings implements \JsonSerializable
+{
+    /**
+     * @var bool
+     */
+    private $enable;
+
+    /**
+     * @var EmailAddress
+     */
+    private $emailAddress;
+
+    /**
+     * @param bool $enable
+     * @param EmailAddress $emailAddress
+     */
+    public function __construct($enable, EmailAddress $emailAddress)
+    {
+        $this->validateBoolean($enable);
+        $this->enable       = $enable;
+        $this->emailAddress = $emailAddress;
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'enable' => $this->enable,
+            'email'  => $this->emailAddress
+        ];
+    }
+
+    /**
+     * @param $enable
+     */
+    private function validateBoolean($enable)
+    {
+        if (!is_bool($enable)) {
+            throw new \InvalidArgumentException('Argument must be boolean');
+        }
+    }
+}

--- a/src/Mail/Setting/ByPassListManagement.php
+++ b/src/Mail/Setting/ByPassListManagement.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace SendGrid\Mail\Setting;
+
+final class ByPassListManagement implements \JsonSerializable
+{
+    /**
+     * @var bool
+     */
+    private $enable;
+
+    /**
+     * @param bool $enable
+     */
+    public function __construct($enable)
+    {
+        $this->validateScalar($enable);
+        $this->enable = $enable;
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'enable' => $this->enable
+        ];
+    }
+
+    /**
+     * @param $value
+     */
+    private function validateScalar($value)
+    {
+        if (!is_bool($value)) {
+            throw new \InvalidArgumentException('Argument must be boolean');
+        }
+    }
+}

--- a/src/Mail/Setting/ClickTracking.php
+++ b/src/Mail/Setting/ClickTracking.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace SendGrid\Mail\Setting;
+
+final class ClickTracking implements \JsonSerializable
+{
+    /**
+     * @var bool
+     */
+    private $enable;
+
+    /**
+     * @var bool
+     */
+    private $enableText;
+
+    /**
+     * @param bool $enable
+     * @param bool $enableText
+     */
+    public function __construct($enable, $enableText)
+    {
+        $this->validateScalar($enable, $enableText);
+        $this->enable     = $enable;
+        $this->enableText = $enableText;
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'enable'      => $this->enable,
+            'enable_text' => $this->enableText
+        ];
+    }
+
+    /**
+     * @param bool $enable
+     * @param bool $enableText
+     * @throws \InvalidArgumentException
+     */
+    private function validateScalar($enable, $enableText)
+    {
+        if (!is_bool($enable) || !is_bool($enableText)) {
+            throw new \InvalidArgumentException('Arguments must be boolean and string');
+        }
+    }
+}

--- a/src/Mail/Setting/Exception/BccSettingIsAlreadySetException.php
+++ b/src/Mail/Setting/Exception/BccSettingIsAlreadySetException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace SendGrid\Mail\Setting\Exception;
+
+final class BccSettingIsAlreadySetException extends SettingIsAlreadySetException
+{
+    const ELEMENT = 'Bcc';
+}

--- a/src/Mail/Setting/Exception/ByPassListManagementSettingIsAlreadySetException.php
+++ b/src/Mail/Setting/Exception/ByPassListManagementSettingIsAlreadySetException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace SendGrid\Mail\Setting\Exception;
+
+final class ByPassListManagementSettingIsAlreadySetException extends SettingIsAlreadySetException
+{
+    const ELEMENT = 'Bypass list management';
+}

--- a/src/Mail/Setting/Exception/ClickTrackingIsAlreadySetException.php
+++ b/src/Mail/Setting/Exception/ClickTrackingIsAlreadySetException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace SendGrid\Mail\Setting\Exception;
+
+final class ClickTrackingIsAlreadySetException extends SettingIsAlreadySetException
+{
+    const ELEMENT = 'Click tracking';
+}

--- a/src/Mail/Setting/Exception/FooterSettingIsAlreadySetException.php
+++ b/src/Mail/Setting/Exception/FooterSettingIsAlreadySetException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace SendGrid\Mail\Setting\Exception;
+
+final class FooterSettingIsAlreadySetException extends SettingIsAlreadySetException
+{
+    const ELEMENT = 'Footer';
+}

--- a/src/Mail/Setting/Exception/GoogleAnalyticsSettingIsAlreadySetException.php
+++ b/src/Mail/Setting/Exception/GoogleAnalyticsSettingIsAlreadySetException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace SendGrid\Mail\Setting\Exception;
+
+final class GoogleAnalyticsSettingIsAlreadySetException extends SettingIsAlreadySetException
+{
+    const ELEMENT = 'Google analytics';
+}

--- a/src/Mail/Setting/Exception/MailSettingsIsEmptyException.php
+++ b/src/Mail/Setting/Exception/MailSettingsIsEmptyException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace SendGrid\Mail\Setting\Exception;
+
+final class MailSettingsIsEmptyException extends SettingIsEmptyException
+{
+    const ELEMENT = 'Mail Settings';
+}

--- a/src/Mail/Setting/Exception/OpenTrackingSettingIsAlreadySetException.php
+++ b/src/Mail/Setting/Exception/OpenTrackingSettingIsAlreadySetException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace SendGrid\Mail\Setting\Exception;
+
+final class OpenTrackingSettingIsAlreadySetException extends SettingIsAlreadySetException
+{
+    const ELEMENT = 'Open tracking';
+}

--- a/src/Mail/Setting/Exception/SandBoxModeSettingIsAlreadySetException.php
+++ b/src/Mail/Setting/Exception/SandBoxModeSettingIsAlreadySetException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace SendGrid\Mail\Setting\Exception;
+
+final class SandBoxModeSettingIsAlreadySetException extends SettingIsAlreadySetException
+{
+    const ELEMENT = 'Sandbox mode';
+}

--- a/src/Mail/Setting/Exception/SettingIsAlreadySetException.php
+++ b/src/Mail/Setting/Exception/SettingIsAlreadySetException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace SendGrid\Mail\Setting\Exception;
+
+use SendGrid\SendGrid\Exception\SendGridException;
+
+class SettingIsAlreadySetException extends SendGridException
+{
+    const ELEMENT = 'Setting';
+    const MESSAGE = '%s setting is already set';
+
+    /**
+     * @var string
+     */
+    public $message;
+
+    public function __construct()
+    {
+        $this->message = sprintf(self::MESSAGE, static::ELEMENT);
+    }
+}

--- a/src/Mail/Setting/Exception/SettingIsEmptyException.php
+++ b/src/Mail/Setting/Exception/SettingIsEmptyException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace SendGrid\Mail\Setting\Exception;
+
+use SendGrid\SendGrid\Exception\SendGridException;
+
+class SettingIsEmptyException extends SendGridException
+{
+    const ELEMENT = 'Settings';
+    const MESSAGE = '%s should contain at least one setting';
+
+    /**
+     * @var string
+     */
+    public $message;
+
+    public function __construct()
+    {
+        $this->message = sprintf(self::MESSAGE, static::ELEMENT);
+    }
+}

--- a/src/Mail/Setting/Exception/SpamCheckSettingIsAlreadySetException.php
+++ b/src/Mail/Setting/Exception/SpamCheckSettingIsAlreadySetException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace SendGrid\Mail\Setting\Exception;
+
+final class SpamCheckSettingIsAlreadySetException extends SettingIsAlreadySetException
+{
+    const ELEMENT = 'Spam check';
+}

--- a/src/Mail/Setting/Exception/SubscriptionTrackingSettingIsAlreadySetException.php
+++ b/src/Mail/Setting/Exception/SubscriptionTrackingSettingIsAlreadySetException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace SendGrid\Mail\Setting\Exception;
+
+final class SubscriptionTrackingSettingIsAlreadySetException extends SettingIsAlreadySetException
+{
+    const ELEMENT = 'Subscription tracking';
+}

--- a/src/Mail/Setting/Exception/TrackingSettingsIsEmptyException.php
+++ b/src/Mail/Setting/Exception/TrackingSettingsIsEmptyException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace SendGrid\Mail\Setting\Exception;
+
+final class TrackingSettingsIsEmptyException extends SettingIsEmptyException
+{
+    const ELEMENT = 'Tracking settings';
+}

--- a/src/Mail/Setting/Footer.php
+++ b/src/Mail/Setting/Footer.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace SendGrid\Mail\Setting;
+
+final class Footer implements \JsonSerializable
+{
+    /**
+     * @var bool
+     */
+    private $enable;
+
+    /**
+     * @var string
+     */
+    private $text;
+
+    /**
+     * @var string
+     */
+    private $html;
+
+    /**
+     * @param bool $enable
+     * @param string $text
+     * @param string $html
+     */
+    public function __construct($enable, $text, $html)
+    {
+        $this->validateScalars($enable, $text, $html);
+        $this->enable = $enable;
+        $this->text   = $text;
+        $this->html   = $html;
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            "enable" => $this->enable,
+            "text"   => $this->text,
+            "html"   => $this->html
+        ];
+    }
+
+    /**
+     * @param bool $enable
+     * @param string $text
+     * @param string $html
+     */
+    private function validateScalars($enable, $text, $html)
+    {
+        if (!is_bool($enable) || !is_string($text) || !is_string($html)) {
+            throw new \InvalidArgumentException('Arguments must be boolean and string');
+        }
+    }
+}

--- a/src/Mail/Setting/GoogleAnalytics.php
+++ b/src/Mail/Setting/GoogleAnalytics.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace SendGrid\Mail\Setting;
+
+final class GoogleAnalytics implements \JsonSerializable
+{
+    /**
+     * @var bool
+     */
+    private $enable;
+
+    /**
+     * @var string
+     */
+    private $utmSource;
+
+    /**
+     * @var string
+     */
+    private $utmMedium;
+
+    /**
+     * @var string
+     */
+    private $utmTerm;
+
+    /**
+     * @var string
+     */
+    private $utmContent;
+
+    /**
+     * @var string
+     */
+    private $utmCampaign;
+
+    /**
+     * @param bool $enable
+     * @param string $utmSource
+     * @param string $utmMedium
+     * @param string $utmTerm
+     * @param string $utmContent
+     * @param string $utmCampaign
+     */
+    public function __construct($enable, $utmSource, $utmMedium, $utmTerm, $utmContent, $utmCampaign)
+    {
+        $this->validateScalar($enable, $utmSource, $utmMedium, $utmTerm, $utmContent, $utmCampaign);
+        $this->enable      = $enable;
+        $this->utmSource   = $utmSource;
+        $this->utmMedium   = $utmMedium;
+        $this->utmTerm     = $utmTerm;
+        $this->utmContent  = $utmContent;
+        $this->utmCampaign = $utmCampaign;
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            "enable"       => $this->enable,
+            "utm_source"   => $this->utmSource,
+            "utm_medium"   => $this->utmMedium,
+            "utm_term"     => $this->utmTerm,
+            "utm_content"  => $this->utmContent,
+            "utm_campaign" => $this->utmContent
+        ];
+    }
+
+    /**
+     * @param bool $enable
+     * @param string $utmSource
+     * @param string $utmMedium
+     * @param string $utmTerm
+     * @param string $utmContent
+     * @param string $utmCampaign
+     * @throws \InvalidArgumentException
+     */
+    private function validateScalar($enable, $utmSource, $utmMedium, $utmTerm, $utmContent, $utmCampaign)
+    {
+        if (!is_bool($enable)||
+            !is_string($utmSource)||
+            !is_string($utmMedium) ||
+            !is_string($utmTerm) ||
+            !is_string($utmContent) ||
+            !is_string($utmCampaign)
+        ) {
+            throw new \InvalidArgumentException('Arguments must be  boolean and string');
+        }
+    }
+}

--- a/src/Mail/Setting/MailSettings.php
+++ b/src/Mail/Setting/MailSettings.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace SendGrid\Mail\Setting;
+
+use SendGrid\Mail\Setting\Exception\BccSettingIsAlreadySetException;
+use SendGrid\Mail\Setting\Exception\FooterSettingIsAlreadySetException;
+use SendGrid\Mail\Setting\Exception\SpamCheckSettingIsAlreadySetException;
+use SendGrid\Mail\Setting\Exception\SandBoxModeSettingIsAlreadySetException;
+use SendGrid\Mail\Setting\Exception\ByPassListManagementSettingIsAlreadySetException;
+
+final class MailSettings implements \JsonSerializable
+{
+    /**
+     * @var BccSettings|null
+     */
+    private $bccSettings;
+
+    /**
+     * @var ByPassListManagement|null
+     */
+    private $byPassListManagement;
+
+    /**
+     * @var Footer|null
+     */
+    private $footer;
+
+    /**
+     * @var SandBoxMode|null
+     */
+    private $sandBoxMode;
+
+    /**
+     * @var SpamCheck|null
+     */
+    private $spamCheck;
+
+    /**
+     * @param BccSettings $bccSettings
+     * @return MailSettings
+     * @throws BccSettingIsAlreadySetException
+     */
+    public function addBcc(BccSettings $bccSettings)
+    {
+        if ($this->hasBccSettings()) {
+            throw new BccSettingIsAlreadySetException;
+        }
+        $this->bccSettings = $bccSettings;
+
+        return $this;
+    }
+
+    /**
+     * @param ByPassListManagement $byPassListManagement
+     * @return MailSettings
+     * @throws ByPassListManagementSettingIsAlreadySetException
+     */
+    public function addByPassListManagement(ByPassListManagement $byPassListManagement)
+    {
+        if ($this->hasBypassListManagement()) {
+            throw new ByPassListManagementSettingIsAlreadySetException;
+        }
+        $this->byPassListManagement = $byPassListManagement;
+
+        return $this;
+    }
+
+    /**
+     * @param Footer $footer
+     * @return MailSettings
+     * @throws FooterSettingIsAlreadySetException
+     */
+    public function addFooter(Footer $footer)
+    {
+        if ($this->hasFooter()) {
+            throw new FooterSettingIsAlreadySetException;
+        }
+        $this->footer = $footer;
+
+        return $this;
+    }
+
+    /**
+     * @param SandBoxMode $sandBoxMode
+     * @return MailSettings
+     * @throws SandBoxModeSettingIsAlreadySetException
+     */
+    public function addSandBoxMode(SandBoxMode $sandBoxMode)
+    {
+        if ($this->hasSandBoxMode()) {
+            throw new SandBoxModeSettingIsAlreadySetException;
+        }
+        $this->sandBoxMode = $sandBoxMode;
+
+        return $this;
+    }
+
+    /**
+     * @param SpamCheck $spamCheck
+     * @return MailSettings
+     * @throws SpamCheckSettingIsAlreadySetException
+     */
+    public function addSpamCheck(SpamCheck $spamCheck)
+    {
+        if ($this->hasSpamCheck()) {
+            throw new SpamCheckSettingIsAlreadySetException;
+        }
+        $this->spamCheck = $spamCheck;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEmpty()
+    {
+        return
+            null === $this->bccSettings &&
+            null === $this->byPassListManagement &&
+            null === $this->footer &&
+            null === $this->sandBoxMode &&
+            null === $this->spamCheck;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasBccSettings()
+    {
+        return null !== $this->bccSettings;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasBypassListManagement()
+    {
+        return null !== $this->byPassListManagement;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasFooter()
+    {
+        return null !== $this->footer;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasSandBoxMode()
+    {
+        return null !== $this->sandBoxMode;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasSpamCheck()
+    {
+        return null !== $this->spamCheck;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function jsonSerialize()
+    {
+        if ($this->isEmpty()) {
+            return null;
+        }
+        return array_filter($this->getProperties(), function ($value) {
+            return $value !== null;
+        });
+    }
+
+    /**
+     * @return array
+     */
+    private function getProperties()
+    {
+        return [
+            'bcc'                    => $this->bccSettings,
+            'bypass_list_management' => $this->byPassListManagement,
+            'footer'                 => $this->footer,
+            'sandbox_mode'           => $this->sandBoxMode,
+            'spam_check'             => $this->spamCheck
+        ];
+    }
+}

--- a/src/Mail/Setting/OpenTracking.php
+++ b/src/Mail/Setting/OpenTracking.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace SendGrid\Mail\Setting;
+
+final class OpenTracking implements \JsonSerializable
+{
+    /**
+     * @var bool
+     */
+    private $enable;
+
+    /**
+     * @var string
+     */
+    private $substitutionTag;
+
+    /**
+     * @param bool $enable
+     * @param string $substitutionTag
+     */
+    public function __construct($enable, $substitutionTag)
+    {
+        $this->validateScalar($enable, $substitutionTag);
+        $this->enable          = $enable;
+        $this->substitutionTag = $substitutionTag;
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            "enable"           => $this->enable,
+            "substitution_tag" => $this->substitutionTag
+        ];
+    }
+
+    /**
+     * @param $enable
+     * @param $substitutionTag
+     * @return void
+     * @throws \InvalidArgumentException
+     */
+    private function validateScalar($enable, $substitutionTag)
+    {
+        if (!is_bool($enable) || !is_string($substitutionTag)) {
+            throw new \InvalidArgumentException;
+        }
+    }
+}

--- a/src/Mail/Setting/SandBoxMode.php
+++ b/src/Mail/Setting/SandBoxMode.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace SendGrid\Mail\Setting;
+
+final class SandBoxMode implements \JsonSerializable
+{
+    /**
+     * @var bool
+     */
+    private $enable;
+
+    /**
+     * @param bool $enable
+     */
+    public function __construct($enable)
+    {
+        $this->validateBoolean($enable);
+        $this->enable = $enable;
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'enable' => $this->enable
+        ];
+    }
+
+    /**
+     * @param $enable
+     */
+    private function validateBoolean($enable)
+    {
+        if (!is_bool($enable)) {
+            throw new \InvalidArgumentException;
+        }
+    }
+}

--- a/src/Mail/Setting/SpamCheck.php
+++ b/src/Mail/Setting/SpamCheck.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace SendGrid\Mail\Setting;
+
+final class SpamCheck implements \JsonSerializable
+{
+    /**
+     * @var bool
+     */
+    private $enable;
+
+    /**
+     * @var int
+     */
+    private $threshold;
+
+    /**
+     * @var string
+     */
+    private $postToUrl;
+
+    /**
+     * @param bool $enable
+     * @param int $threshold
+     * @param string $postToUrl
+     */
+    public function __construct($enable, $threshold, $postToUrl)
+    {
+        $this->validateScalars($enable, $threshold, $postToUrl);
+        $this->enable    = $enable;
+        $this->threshold = $threshold;
+        $this->postToUrl = $postToUrl;
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            "enable"      => $this->enable,
+            "threshold"   => $this->threshold,
+            "post_to_url" => $this->postToUrl
+        ];
+    }
+
+    /**
+     * @param bool $enable
+     * @param string $threshold
+     * @param string $postToUrl
+     */
+    private function validateScalars($enable, $threshold, $postToUrl)
+    {
+        if (!is_bool($enable) || !is_int($threshold) || !is_string($postToUrl)) {
+            throw new \InvalidArgumentException;
+        }
+    }
+}

--- a/src/Mail/Setting/SubscriptionTracking.php
+++ b/src/Mail/Setting/SubscriptionTracking.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace SendGrid\Mail\Setting;
+
+final class SubscriptionTracking implements \JsonSerializable
+{
+    /**
+     * @var bool
+     */
+    private $enable;
+
+    /**
+     * @var string
+     */
+    private $text;
+
+    /**
+     * @var string
+     */
+    private $html;
+
+    /**
+     * @var string
+     */
+    private $substitutionTag;
+
+    /**
+     * @param bool $enable
+     * @param string $text
+     * @param string $html
+     * @param string $substitutionTag
+     */
+    public function __construct($enable, $text, $html, $substitutionTag)
+    {
+        $this->validateScalars($enable, $text, $html, $substitutionTag);
+        $this->enable          = $enable;
+        $this->text            = $text;
+        $this->html            = $html;
+        $this->substitutionTag = $substitutionTag;
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            "enable"           => $this->enable,
+            "text"             => $this->text,
+            "html"             => $this->html,
+            "substitution_tag" => $this->substitutionTag
+        ];
+    }
+
+    /**
+     * @param bool $enable
+     * @param string $text
+     * @param string $html
+     * @param string $substitutionTag
+     * @return void
+     * @throws \InvalidArgumentException
+     */
+    private function validateScalars($enable, $text, $html, $substitutionTag)
+    {
+        if (!is_bool($enable) || !is_string($text) || !is_string($html) || !is_string($substitutionTag)) {
+            throw new \InvalidArgumentException('Arguments must be boolean adn string');
+        }
+    }
+}

--- a/src/Mail/Setting/TrackingSettings.php
+++ b/src/Mail/Setting/TrackingSettings.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace SendGrid\Mail\Setting;
+
+use SendGrid\Mail\Setting\Exception\ClickTrackingIsAlreadySetException;
+use SendGrid\Mail\Setting\Exception\OpenTrackingSettingIsAlreadySetException;
+use SendGrid\Mail\Setting\Exception\GoogleAnalyticsSettingIsAlreadySetException;
+use SendGrid\Mail\Setting\Exception\SubscriptionTrackingSettingIsAlreadySetException;
+
+final class TrackingSettings implements \JsonSerializable
+{
+    /**
+     * @var ClickTracking|null
+     */
+    private $clickTracking;
+
+    /**
+     * @var  OpenTracking|null
+     */
+    private $openTracking;
+
+    /**
+     * @var  SubscriptionTracking|null
+     */
+    private $subscriptionTracking;
+
+    /**
+     * @var  GoogleAnalytics|null
+     */
+    private $googleAnalytics;
+
+    /**
+     * @param ClickTracking $clickTracking
+     * @return TrackingSettings
+     * @throws ClickTrackingIsAlreadySetException
+     */
+    public function addClickTracking(ClickTracking $clickTracking)
+    {
+        if ($this->hasClickTracking()) {
+            throw new ClickTrackingIsAlreadySetException;
+        }
+        $this->clickTracking = $clickTracking;
+
+        return $this;
+    }
+
+    /**
+     * @param OpenTracking $openTracking
+     * @return TrackingSettings
+     * @throws OpenTrackingSettingIsAlreadySetException
+     */
+    public function addOpenTracking(OpenTracking $openTracking)
+    {
+        if ($this->hasOpenTracking()) {
+            throw new OpenTrackingSettingIsAlreadySetException;
+        }
+        $this->openTracking = $openTracking;
+
+        return $this;
+    }
+
+    /**
+     * @param SubscriptionTracking $subscriptionTracking
+     * @return TrackingSettings
+     * @throws SubscriptionTrackingSettingIsAlreadySetException
+     */
+    public function addSubscriptionTracking(SubscriptionTracking $subscriptionTracking)
+    {
+        if ($this->hasSubscriptionTracking()) {
+            throw new SubscriptionTrackingSettingIsAlreadySetException;
+        }
+        $this->subscriptionTracking = $subscriptionTracking;
+
+        return $this;
+    }
+
+    /**
+     * @param GoogleAnalytics $googleAnalytics
+     * @return TrackingSettings
+     * @throws GoogleAnalyticsSettingIsAlreadySetException
+     */
+    public function addGoogleAnalytics(GoogleAnalytics $googleAnalytics)
+    {
+        if ($this->hasGoogleAnalytics()) {
+            throw new GoogleAnalyticsSettingIsAlreadySetException;
+        }
+        $this->googleAnalytics = $googleAnalytics;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEmpty()
+    {
+        return
+            null === $this->clickTracking &&
+            null === $this->openTracking &&
+            null === $this->subscriptionTracking &&
+            null === $this->googleAnalytics;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasClickTracking()
+    {
+        return null !== $this->clickTracking;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasOpenTracking()
+    {
+        return null !== $this->openTracking;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasSubscriptionTracking()
+    {
+        return null !== $this->subscriptionTracking;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasGoogleAnalytics()
+    {
+        return null !== $this->googleAnalytics;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function jsonSerialize()
+    {
+        if ($this->isEmpty()) {
+            return null;
+        }
+        return array_filter($this->getProperties(), function ($value) {
+            return $value !== null;
+        });
+    }
+
+    /**
+     * @return array
+     */
+    private function getProperties()
+    {
+        return [
+            "click_tracking"        => $this->clickTracking,
+            "open_tracking"         => $this->openTracking,
+            "subscription_tracking" => $this->subscriptionTracking,
+            "ganalytics"            => $this->googleAnalytics
+        ];
+    }
+}

--- a/src/Mail/ValueObject/EmailAddress.php
+++ b/src/Mail/ValueObject/EmailAddress.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace SendGrid\Mail\ValueObject;
+
+use SendGrid\Mail\Exception\InvalidEmailAddressException;
+
+class EmailAddress implements \JsonSerializable
+{
+    /**
+     * @var string
+     */
+    private $address;
+
+    /**
+     * @var string|null
+     */
+    private $name;
+
+    /**
+     * @param string $address
+     * @param string|null $name
+     * @throws \Exception
+     */
+    public function __construct($address, $name = null)
+    {
+        $this->validateScalar($address, $name);
+        $this->address = $this->valid($address);
+        $this->name    = $name;
+    }
+
+    /**
+     * @param $address
+     * @return string
+     * @throws InvalidEmailAddressException
+     */
+    private function valid($address)
+    {
+        if ($this->isValid($address)) {
+            return $address;
+        }
+        throw new InvalidEmailAddressException($address);
+    }
+
+    /**
+     * @param $value
+     * @return bool
+     */
+    private function isValid($value)
+    {
+        return filter_var($value, FILTER_VALIDATE_EMAIL) ? true : false;
+    }
+
+    /**
+     * @param $address
+     * @param $name
+     * @throws \Exception
+     * @return void
+     */
+    private function validateScalar($address, $name)
+    {
+        if (!is_string($address) || null !== $name && !is_string($name)) {
+            throw new \Exception('Arguments must be string');
+        }
+    }
+
+    /**
+     * @return array|string
+     */
+    public function jsonSerialize()
+    {
+        if (null !== $this->name) {
+            return [
+                'name'  => $this->name,
+                'email' => $this->address
+            ];
+        }
+        return $this->address;
+    }
+}

--- a/src/SendGrid/Exception/SendGridException.php
+++ b/src/SendGrid/Exception/SendGridException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace SendGrid\SendGrid\Exception;
+
+class SendGridException extends \Exception
+{
+
+}

--- a/src/SendGrid/SendGrid.php
+++ b/src/SendGrid/SendGrid.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace SendGrid\SendGrid\Entity;
+
+use SendGrid\Client;
+use SendGrid\Response;
+use SendGrid\Mail\Mail;
+
+final class SendGrid
+{
+    const VERSION       = '6.0.0';
+    const AUTHORIZATION = 'Authorization: Bearer %s';
+    const AGENT         = 'User-Agent: sendgrid/%s;php';
+    const ACCEPT        = 'Accept: application/json';
+    const DEFAULT_URL   = 'https://api.sendgrid.com';
+
+    /**
+     * @var Client
+     */
+    private $client;
+
+    /**
+     * Setup the HTTP Client
+     *
+     * @param string $apiKey  your SendGrid API Key.
+     * @param array  $options an array of Option, currently only "host" and "curl" are implemented.
+     */
+    public function __construct($apiKey, array $options = [])
+    {
+        $this->client = $this->createClientFrom($apiKey, $options);
+    }
+
+    /**
+     * @return Client
+     */
+    public function getClient()
+    {
+        return $this->client;
+    }
+
+    /**
+     * @param Mail $mail
+     * @return Response
+     */
+    public function send(Mail $mail)
+    {
+        return $this->sendUsing($mail);
+    }
+
+    /**
+     * @param $json
+     * @return Response
+     */
+    public function sendFromJson($json)
+    {
+        return $this->sendUsing($json);
+    }
+
+    /**
+     * @param Mail|string $object
+     * @return Response
+     */
+    private function sendUsing($object)
+    {
+        return $this->client->mail()->send()->post($object);
+    }
+    /**
+     * @param string $apiKey
+     * @param array $options
+     * @return Client
+     */
+    private function createClientFrom($apiKey, array $options)
+    {
+        $this->validateScalar($apiKey);
+        $host          = isset($options['host']) ? $options['host'] : self::DEFAULT_URL;
+        $curlOptions   = isset($options['curl']) ? $options['curl'] : null;
+        return new Client($host, $this->getHeadersFrom($apiKey), '/v3', null, $curlOptions);
+    }
+
+    /**
+     * @param string $apiKey
+     * @return array
+     */
+    private function getHeadersFrom($apiKey)
+    {
+        return [
+            sprintf(self::AUTHORIZATION, $apiKey),
+            sprintf(self::AGENT, self::VERSION),
+            self::ACCEPT
+        ];
+    }
+
+    /**
+     * @param $value
+     */
+    private function validateScalar($value)
+    {
+        if (!is_string($value)) {
+            throw new \InvalidArgumentException('Api KEY must be a string');
+        }
+    }
+}

--- a/tests/Asm/AsmTest.php
+++ b/tests/Asm/AsmTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Test\Asm;
+
+use SendGrid\Mail\Optional\Asm;
+
+final class AsmTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     * @return void
+     */
+    public function itShouldSerializeSuccessfully()
+    {
+        $this->assertSame(
+            json_encode(new Asm(99, [4,5,6])),
+            $this->getExpectedDecoded()
+        );
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedDecoded()
+    {
+        return json_encode(
+            json_decode($this->getExpectedJson())
+        );
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedJson()
+    {
+        return <<<JSON
+        {
+           "group_id":99,
+           "groups_to_display":[
+              4,
+              5,
+              6
+           ]
+        }
+JSON;
+    }
+}

--- a/tests/Attachment/AttachmentTest.php
+++ b/tests/Attachment/AttachmentTest.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace Test\Attachment;
+
+use SendGrid\Mail\Optional\Attachment;
+use SendGrid\Mail\Optional\Collection\AttachmentCollection;
+
+final class AttachmentTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @param string $content
+     * @param string $type
+     * @param string $name
+     * @param string $disposition
+     * @param string|null$id
+     * @return void
+     * @dataProvider attachmentProvider
+     * @test
+     */
+    public function itShouldSerializeSuccessfully($content, $type, $name, $disposition, $id)
+    {
+        $this->assertSame(
+            json_encode(new Attachment($content, $type, $name, $disposition, $id)),
+            $this->getExpectedDecodedFrom($content, $type, $name, $disposition, $id)
+        );
+    }
+
+    /**
+     * @return void
+     * @test
+     */
+    public function itShouldSerializeSuccessfullyFromCollection()
+    {
+        $attachments = new AttachmentCollection([
+            new Attachment('content', 'type', 'name', 'disposition', 'anId'),
+            new Attachment('otherContent', 'otherType', 'otherName', 'otherDisposition', 'otherId')
+        ]);
+        $this->assertSame(
+            json_encode($attachments),
+            $this->getExpectedDecodedFromCollection()
+        );
+    }
+
+    /**
+     * @return void
+     * @test
+     */
+    public function itShouldAddAttachmentSuccessfully()
+    {
+        $attachments = new AttachmentCollection([
+            new Attachment('content', 'type', 'name', 'disposition', 'anId'),
+        ]);
+        $this->assertSame(1, $attachments->count());
+
+        $attachments->add(new Attachment('otherContent', 'otherType', 'otherName', 'otherDisposition', 'otherId'));
+        $this->assertSame(2, $attachments->count());
+
+        $attachments->addMany([
+            new Attachment('fromMany', 'typeFromMany', 'nameFromMany', 'dispositionFromMany', 'idFromMany'),
+            new Attachment('I', 'Am', 'a', 'new', 'attachment')
+        ]);
+        $this->assertSame(4, $attachments->count());
+    }
+
+    /**
+     * @return void
+     * @test
+     * @expectedException \InvalidArgumentException
+     */
+    public function itShouldValidateScalar()
+    {
+        new Attachment(1, 2, 3, null);
+    }
+
+    /**
+     * @return array
+     */
+    public function attachmentProvider()
+    {
+        return [
+            [
+                'TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gQ3JhcyBwdW12',
+                'application/pdf',
+                'balance_001.pdf',
+                'attachment',
+                'Balance Sheet'
+            ],
+            [
+                'TG9yZW0gad8sa9dad90a7sd08as7da89d6as89d6as98d6as9d86asd79as6d98a6d8as9d7as8dada',
+                'application/vnd.ms-excel',
+                'test.xlx',
+                'attachment',
+                null
+            ]
+        ];
+    }
+
+    /**
+     * @param string $content
+     * @param string $type
+     * @param string $name
+     * @param string $disposition
+     * @param string|null $id
+     * @return string
+     */
+    private function getExpectedDecodedFrom($content, $type, $name, $disposition, $id)
+    {
+        return json_encode(
+            json_decode($this->getExpectedJsonFrom($content, $type, $name, $disposition, $id))
+        );
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedDecodedFromCollection()
+    {
+        return json_encode(
+            json_decode($this->getExpectedJsonFromCollection())
+        );
+    }
+
+    /**
+     * @param string $content
+     * @param string $type
+     * @param string $name
+     * @param string $disposition
+     * @param string|null $id
+     * @return string
+     */
+    private function getExpectedJsonFrom($content, $type, $name, $disposition, $id)
+    {
+        if (null === $id) {
+            return <<<JSON
+            {
+                "content"     : "{$content}",
+                "type"        : "{$type}",
+                "filename"    : "{$name}",
+                "disposition" : "{$disposition}"
+            }
+JSON;
+        }
+        return <<<JSON
+        {
+            "content"     : "{$content}",
+            "type"        : "{$type}",
+            "filename"    : "{$name}",
+            "disposition" : "{$disposition}",
+            "content_id"  : "{$id}"
+        }
+JSON;
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedJsonFromCollection()
+    {
+        return <<<JSON
+        [
+           {
+              "content"     :"content",
+              "type"        :"type",
+              "filename"    :"name",
+              "disposition" :"disposition",
+              "content_id"  :"anId"
+           },
+           {
+              "content"     :"otherContent",
+              "type"        :"otherType",
+              "filename"    :"otherName",
+              "disposition" :"otherDisposition",
+              "content_id"  :"otherId"
+           }
+        ]
+JSON;
+    }
+}

--- a/tests/Category/CategoryTest.php
+++ b/tests/Category/CategoryTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Test\Category;
+
+use SendGrid\Mail\Optional\Collection\CategoryCollection;
+use SendGrid\Mail\Optional\Category;
+
+final class CategoryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @return void
+     * @test
+     */
+    public function itShouldSerializeSuccessfully()
+    {
+        $categories = new CategoryCollection([
+            new Category('May'),
+            new Category('2017'),
+            new Category('Other Category'),
+            new Category('Last Category')
+        ]);
+
+        $this->assertSame(
+            json_encode($categories),
+            $this->getExpectedEncodedJson()
+        );
+    }
+
+    /**
+     * @return void
+     * @test
+     */
+    public function itShouldAddToCollectionSuccessfully()
+    {
+        $categories = new CategoryCollection([
+            new Category('May')
+        ]);
+        $this->assertSame(1, $categories->count());
+
+        $categories->add(new Category('2017'));
+        $this->assertSame(2, $categories->count());
+
+        $categories->addMany([
+            new Category('Other Category'),
+            new Category('Last Category')
+        ]);
+        $this->assertSame(4, $categories->count());
+    }
+
+    /**
+     * @return void
+     * @test
+     * @expectedException \InvalidArgumentException
+     */
+    public function itShouldValidateScalar()
+    {
+        new Category(true);
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedEncodedJson()
+    {
+        return json_encode(
+            json_decode($this->getExpectedJson())
+        );
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedJson()
+    {
+        return <<<JSON
+        [
+           "May",
+           "2017",
+           "Other Category",
+           "Last Category"
+        ]
+JSON;
+    }
+}

--- a/tests/Content/ContentTest.php
+++ b/tests/Content/ContentTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Test\Content;
+
+use SendGrid\Mail\Essential\Content;
+use SendGrid\Mail\Essential\Collection\ContentCollection;
+
+final class ContentTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @param string $type
+     * @param string $value
+     * @return void
+     * @test
+     * @dataProvider keyValueProvider
+     */
+    public function itShouldSerializeSuccessfully($type, $value)
+    {
+        $this->assertSame(
+            json_encode(new Content($type, $value)),
+            $this->getExpectedDecodedFrom($type, $value)
+        );
+    }
+
+    /**
+     * @return void
+     * @test
+     */
+    public function itShouldSerializeSuccessfullyFromCollection()
+    {
+        $contents = new ContentCollection([
+            new Content('type', 'value'),
+            new Content('otherType', 'otherValue')
+        ]);
+        $this->assertSame(
+            json_encode($contents),
+            $this->getExpectedDecodedFromCollection()
+        );
+    }
+
+    /**
+     * @return void
+     * @test
+     */
+    public function itShouldAddAttachmentSuccessfully()
+    {
+        $contents = new ContentCollection([
+            new Content('type', 'value'),
+        ]);
+        $this->assertSame(1, $contents->count());
+
+        $contents->add(new Content('otherType', 'otherValue'));
+        $this->assertSame(2, $contents->count());
+
+        $contents->addMany([
+            new Content('typeFromMany', 'valueFromMany'),
+            new Content('I am a Type', 'I am a Value')
+        ]);
+        $this->assertSame(4, $contents->count());
+    }
+
+    /**
+     * @return void
+     * @test
+     * @expectedException \InvalidArgumentException
+     */
+    public function itShouldValidateScalar()
+    {
+        new Content(1, true);
+    }
+
+    /**
+     * @return array
+     */
+    public function keyValueProvider()
+    {
+        return [
+            [
+                'text/plain',
+                'Some text here'
+            ],
+            [
+                'text/html',
+                '<html><body>some text here</body></html>'
+            ]
+        ];
+    }
+
+    /**
+     * @param string $type
+     * @param string $value
+     * @return string
+     */
+    private function getExpectedDecodedFrom($type, $value)
+    {
+        return json_encode(
+            json_decode($this->getExpectedJsonFrom($type, $value))
+        );
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedDecodedFromCollection()
+    {
+        return json_encode(
+            json_decode($this->getExpectedJsonFromCollection())
+        );
+    }
+
+    /**
+     * @param string $type
+     * @param string $value
+     * @return string
+     */
+    public function getExpectedJsonFrom($type, $value)
+    {
+        return <<<JSON
+        {
+           "type"  : "{$type}",
+           "value" : "{$value}"
+        }
+JSON;
+    }
+
+    /**
+     * @return string
+     */
+    public function getExpectedJsonFromCollection()
+    {
+        return <<<JSON
+        [
+           {
+              "type"  : "type",
+              "value" : "value"
+           },
+           {
+              "type"  : "otherType",
+              "value" : "otherValue"
+           }
+        ]
+JSON;
+    }
+}

--- a/tests/CustomArgument/CustomArgumentTest.php
+++ b/tests/CustomArgument/CustomArgumentTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Test\CustomArgument;
+
+use SendGrid\Mail\Optional\Collection\CustomArgumentCollection;
+use SendGrid\Mail\Optional\CustomArgument;
+
+final class CustomArgumentTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @param string $key
+     * @param string $value
+     * @return void
+     * @test
+     * @dataProvider keyValueProvider
+     */
+    public function itShouldSerializeSuccessfully($key, $value)
+    {
+        $this->assertSame(
+            json_encode(new CustomArgument($key, $value)),
+            $this->getExpectedDecodedFrom($key, $value)
+        );
+    }
+
+    /**
+     * @return void
+     * @test
+     */
+    public function itShouldSerializeSuccessfullyFromCollection()
+    {
+        $contents = new CustomArgumentCollection([
+            new CustomArgument('key', 'value'),
+            new CustomArgument('otherKey', 'otherValue'),
+            new CustomArgument('thirdKey', 'thirdValue')
+        ]);
+        $this->assertSame(
+            json_encode($contents),
+            $this->getExpectedDecodedFromCollection()
+        );
+    }
+
+    /**
+     * @return void
+     * @test
+     */
+    public function itShouldAddAttachmentSuccessfully()
+    {
+        $customArguments = new CustomArgumentCollection([
+            new CustomArgument('key', 'value'),
+        ]);
+        $this->assertSame(1, $customArguments->count());
+
+        $customArguments->add(new CustomArgument('otherKey', 'otherValue'));
+        $this->assertSame(2, $customArguments->count());
+
+        $customArguments->addMany([
+            new CustomArgument('keyFromMany', 'valueFromMany'),
+            new CustomArgument('aKey', 'aValue')
+        ]);
+        $this->assertSame(4, $customArguments->count());
+    }
+
+    /**
+     * @return void
+     * @test
+     * @expectedException \InvalidArgumentException
+     */
+    public function itShouldValidateScalar()
+    {
+        new CustomArgument(1, false);
+    }
+
+    /**
+     * @return array
+     */
+    public function keyValueProvider()
+    {
+        return [
+            [
+                'campaign',
+                'welcome'
+            ],
+            [
+                'weekday',
+                'morning'
+            ]
+        ];
+    }
+
+    /**
+     * @param string $key
+     * @param string $value
+     * @return string
+     */
+    private function getExpectedDecodedFrom($key, $value)
+    {
+        return json_encode(
+            json_decode($this->getExpectedJsonFrom($key, $value))
+        );
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedDecodedFromCollection()
+    {
+        return json_encode(
+            json_decode($this->getExpectedJsonFromCollection())
+        );
+    }
+
+    /**
+     * @param string $key
+     * @param string $value
+     * @return string
+     */
+    public function getExpectedJsonFrom($key, $value)
+    {
+        return <<<JSON
+        {
+           "{$key}" : "{$value}"
+        }
+JSON;
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedJsonFromCollection()
+    {
+        return <<<JSON
+        {
+           "key"      : "value",
+           "otherKey" : "otherValue",
+           "thirdKey" : "thirdValue"
+        }
+JSON;
+    }
+}

--- a/tests/Header/HeaderTest.php
+++ b/tests/Header/HeaderTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Test\Header;
+
+use SendGrid\Mail\Optional\Collection\HeaderCollection;
+use SendGrid\Mail\Optional\Header;
+
+final class HeaderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @param string $key
+     * @param string $value
+     * @return void
+     * @test
+     * @dataProvider keyValueProvider
+     */
+    public function itShouldSerializeSuccessfully($key, $value)
+    {
+        $this->assertSame(
+            json_encode(new Header($key, $value)),
+            $this->getExpectedDecodedFrom($key, $value)
+        );
+    }
+
+    /**
+     * @return void
+     * @test
+     */
+    public function itShouldSerializeSuccessfullyFromCollection()
+    {
+        $contents = new HeaderCollection([
+            new Header('key', 'value'),
+            new Header('otherKey', 'otherValue'),
+            new Header('thirdKey', 'thirdValue')
+        ]);
+        $this->assertSame(
+            json_encode($contents),
+            $this->getExpectedDecodedFromCollection()
+        );
+    }
+
+    /**
+     * @return void
+     * @test
+     */
+    public function itShouldAddAttachmentSuccessfully()
+    {
+        $customArguments = new HeaderCollection([
+            new Header('key', 'value'),
+        ]);
+        $this->assertSame(1, $customArguments->count());
+
+        $customArguments->add(new Header('otherKey', 'otherValue'));
+        $this->assertSame(2, $customArguments->count());
+
+        $customArguments->addMany([
+            new Header('keyFromMany', 'valueFromMany'),
+            new Header('aKey', 'aValue')
+        ]);
+        $this->assertSame(4, $customArguments->count());
+    }
+
+    /**
+     * @return void
+     * @test
+     * @expectedException \InvalidArgumentException
+     */
+    public function itShouldValidateScalar()
+    {
+        new Header(1, false);
+    }
+
+    /**
+     * @return array
+     */
+    public function keyValueProvider()
+    {
+        return [
+            [
+                'X-Test1',
+                '1'
+            ],
+            [
+                'X-Test2',
+                '2'
+            ]
+        ];
+    }
+
+    /**
+     * @param string $key
+     * @param string $value
+     * @return string
+     */
+    private function getExpectedDecodedFrom($key, $value)
+    {
+        return json_encode(
+            json_decode($this->getExpectedJsonFrom($key, $value))
+        );
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedDecodedFromCollection()
+    {
+        return json_encode(
+            json_decode($this->getExpectedJsonFromCollection())
+        );
+    }
+
+    /**
+     * @param string $key
+     * @param string $value
+     * @return string
+     */
+    public function getExpectedJsonFrom($key, $value)
+    {
+        return <<<JSON
+        {
+           "{$key}" : "{$value}"
+        }
+JSON;
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedJsonFromCollection()
+    {
+        return <<<JSON
+        {
+           "key"      : "value",
+           "otherKey" : "otherValue",
+           "thirdKey" : "thirdValue"
+        }
+JSON;
+    }
+}

--- a/tests/Mail/MailTest.php
+++ b/tests/Mail/MailTest.php
@@ -1,0 +1,2572 @@
+<?php
+
+namespace Test\Mail;
+
+use SendGrid\Mail\Optional\Asm;
+use SendGrid\Mail\Optional\Attachment;
+use SendGrid\Mail\Optional\Collection\AttachmentCollection;
+use SendGrid\Content;
+use SendGrid\Mail\Essential\Collection\ContentCollection;
+use SendGrid\Mail\Optional\Collection\CustomArgumentCollection;
+use SendGrid\Mail\Optional\CustomArgument;
+use SendGrid\Mail\Optional\Collection\HeaderCollection;
+use SendGrid\Mail\Optional\Header;
+use SendGrid\Mail\Optional\Collection\CategoryCollection;
+use SendGrid\Mail\Optional\Collection\ReplyToCollection;
+use SendGrid\Mail\Essential\Collection\ToCollection;
+use SendGrid\Mail\Mail;
+use SendGrid\Mail\Setting\BccSettings;
+use SendGrid\Mail\Setting\ByPassListManagement;
+use SendGrid\Mail\Setting\ClickTracking;
+use SendGrid\Mail\Setting\Footer;
+use SendGrid\Mail\Setting\GoogleAnalytics;
+use SendGrid\Mail\Setting\MailSettings;
+use SendGrid\Mail\Setting\OpenTracking;
+use SendGrid\Mail\Setting\SandBoxMode;
+use SendGrid\Mail\Setting\SpamCheck;
+use SendGrid\Mail\Setting\SubscriptionTracking;
+use SendGrid\Mail\Optional\Category;
+use SendGrid\Mail\ValueObject\EmailAddress;
+use SendGrid\Mail\Essential\From;
+use SendGrid\Mail\Optional\Subject;
+use SendGrid\Mail\Essential\To;
+use SendGrid\Mail\Optional\Collection\BccCollection;
+use SendGrid\Mail\Optional\Collection\CcCollection;
+use SendGrid\Mail\Optional\Collection\PersonalizationCollection;
+use SendGrid\Mail\Optional\Bcc;
+use SendGrid\Mail\Optional\Cc;
+use SendGrid\ReplyTo;
+use SendGrid\Mail\Optional\Collection\SectionCollection;
+use SendGrid\Mail\Optional\Section;
+use SendGrid\Mail\Optional\Collection\SubstitutionCollection;
+use SendGrid\Mail\Optional\Substitution;
+use SendGrid\Mail\Setting\TrackingSettings;
+
+final class MailTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @return void
+     * @test
+     */
+    public function itShouldSerializeSuccessfully()
+    {
+        $mail = $this->createBaseMailConfig();
+        $this->assertSame(
+            json_encode($mail),
+            $this->getEncoded($this->getExpectedBaseMailJson())
+        );
+
+        $mail->addCcs(new CcCollection([
+            new Cc("test@example.com", "Test User"),
+            new Cc('other@example.com', "Other Test User")
+        ]));
+        $this->assertSame(
+            json_encode($mail),
+            $this->getEncoded($this->getExpectedCcJson())
+        );
+
+        $mail->addBccs(new BccCollection([
+            new Bcc("test@example.com", "Test User"),
+            new Bcc('other@example.com', "Other Test User")
+        ]));
+        $this->assertSame(
+            json_encode($mail),
+            $this->getEncoded($this->getExpectedBccJson())
+        );
+
+        $mail->addHeadersToBasePersonalization(new HeaderCollection([
+            new Header('X-Test', 'test'),
+            new Header('X-Mock', 'true')
+        ]));
+        $this->assertSame(
+            json_encode($mail),
+            $this->getEncoded($this->getExpectedHeaderPersonalizationJson())
+        );
+
+        $mail->addSubstitutions(new SubstitutionCollection([
+            new Substitution('%name%', 'Example User'),
+            new Substitution('%city%', 'Denver')
+        ]));
+        $this->assertSame(
+            json_encode($mail),
+            $this->getEncoded($this->getExpectedSubstitutionJson())
+        );
+
+        $mail->addCustomArgumentsToBasePersonalization(new CustomArgumentCollection([
+            new CustomArgument('user_id', '343'),
+            new CustomArgument('type', 'marketing')
+        ]));
+        $this->assertSame(
+            json_encode($mail),
+            $this->getEncoded($this->getExpectedCustomArgumentPersonalization())
+        );
+        $mail->addAttachments(new AttachmentCollection([
+            new Attachment('content', 'type', 'name', 'disposition', 'anId'),
+            new Attachment('otherContent', 'otherType', 'otherName', 'otherDisposition', 'otherId')
+        ]));
+        $this->assertSame(
+            json_encode($mail),
+            $this->getEncoded($this->getExpectedAttachmentJson())
+        );
+        $mail->addTemplateId('439b6d66-4408-4ead-83de-5c83c2ee313a');
+        $this->assertSame(
+            json_encode($mail),
+            $this->getEncoded($this->getExpectedTemplateIdJson())
+        );
+
+        $mail->addSections(new SectionCollection([
+            new Section('%section1%', 'Substitution Text for Section 1'),
+            new Section('%section1%', 'Substitution Text for Section 2')
+        ]));
+        $this->assertSame(
+            json_encode($mail),
+            $this->getEncoded($this->getExpectedSectionJson())
+        );
+
+        $mail->addHeaders(new HeaderCollection([
+            new Header('X-Test1', '1'),
+            new Header('X-Test2', '2')
+        ]));
+        $this->assertSame(
+            json_encode($mail),
+            $this->getEncoded($this->getExpectedHeaderJson())
+        );
+
+        $mail->addCategories(new CategoryCollection([
+            new Category('May'),
+            new Category('2016')
+        ]));
+        $this->assertSame(
+            json_encode($mail),
+            $this->getEncoded($this->getExpectedCategoryJson())
+        );
+
+        $mail->addCustomArguments(new CustomArgumentCollection([
+            new CustomArgument('campaign', 'welcome'),
+            new CustomArgument('weekday', 'morning')
+        ]));
+        $this->assertSame(
+            json_encode($mail),
+            $this->getEncoded($this->getExpectedCustomArgumentJson())
+        );
+
+        $mail->addAsm(new Asm(99, [4,5,6,7,8]));
+        $this->assertSame(
+            json_encode($mail),
+            $this->getEncoded($this->getExpectedAsmJson())
+        );
+
+        $mail->addIpPoolName('23');
+        $this->assertSame(
+            json_encode($mail),
+            $this->getEncoded($this->getExpectedIpPoolNameJson())
+        );
+
+        $mail->addBccSettings(new BccSettings(true, new EmailAddress('test@example.com')));
+        $this->assertSame(
+            json_encode($mail),
+            $this->getEncoded($this->getExpectedBccSettingsJson())
+        );
+
+        $mail->addByPassListManagement(new ByPassListManagement(true));
+        $this->assertSame(
+            json_encode($mail),
+            $this->getEncoded($this->getExpectedByPassListManagementJson())
+        );
+
+        $mail->addFooter(new Footer(true, 'Footer Text', '<html><body>Footer Text</body></html>'));
+        $this->assertSame(
+            json_encode($mail),
+            $this->getEncoded($this->getExpectedFooterJson())
+        );
+
+        $mail->addSandBoxMode(new SandBoxMode(true));
+        $this->assertSame(
+            json_encode($mail),
+            $this->getEncoded($this->getSandBoxModeExpectedJson())
+        );
+
+        $mail->addSpamCheck(new SpamCheck(true, 1, 'https://spamcatcher.sendgrid.com'));
+        $this->assertSame(
+            json_encode($mail),
+            $this->getEncoded($this->getExpectedSpamCheckJson())
+        );
+        $clickTracking = new ClickTracking(true, true);
+        $openTracking = new OpenTracking(true, 'Optional tag to replace');
+        $googleAnalytics = new GoogleAnalytics(true, 'source', 'medium', 'term', 'content', 'name');
+        $subscriptionTracking = new SubscriptionTracking(
+            true,
+            'text to insert into the text/plain portion of the message',
+            '<html><body>html to insert into the text/html portion of the message</body></html>',
+            'Optional tag to replace with the open image in the body of the message'
+        );
+
+        $trackingSettings = (new TrackingSettings)->addClickTracking($clickTracking)
+                                                  ->addOpenTracking($openTracking)
+                                                  ->addGoogleAnalytics($googleAnalytics)
+                                                  ->addSubscriptionTracking($subscriptionTracking);
+
+        $mail->addTrackingSettings($trackingSettings);
+        $this->assertSame(
+            json_encode($mail),
+            $this->getEncoded($this->getExpectedTrackingSettingsJson())
+        );
+
+        $repliesTo = new ReplyToCollection([
+            new ReplyTo('test@example.com'),
+            new ReplyTo('other@example.com'),
+            new ReplyTo('last@example.com')
+        ]);
+        $mail->addRepliesTo($repliesTo);
+        $this->assertSame(
+            json_encode($mail),
+            $this->getEncoded($this->getExpectedRepliesToJson())
+        );
+    }
+
+    /**
+     * Library should be strict and Mail should always be in a valid state,
+     * therefore, if we try to add an empty collection it should throw an exception
+     *
+     * @return void
+     * @test
+     * @expectedException \SendGrid\Mail\Optional\Exception\PersonalizationCollectionIsEmptyException
+     */
+    public function itShouldFailIfEmptyPersonalizationCollectionIsAdded()
+    {
+        $this->createBaseMailConfig()
+             ->addPersonalizations(new PersonalizationCollection);
+    }
+
+    /**
+     * Library should be strict and Mail should always be in a valid state,
+     * therefore, if we try to add an empty collection it should throw an exception
+     *
+     * @return void
+     * @test
+     * @expectedException \SendGrid\Mail\Optional\Exception\AttachmentCollectionIsEmptyException
+     */
+    public function itShouldFailIfEmptyAttachmentCollectionIsAdded()
+    {
+        $this->createBaseMailConfig()
+             ->addAttachments(new AttachmentCollection);
+    }
+
+    /**
+     * Library should be strict and Mail should always be in a valid state,
+     * therefore, if we try to add an empty collection it should throw an exception
+     *
+     * @return void
+     * @test
+     * @expectedException \SendGrid\Mail\Essential\Exception\ContentCollectionIsEmptyException
+     */
+    public function itShouldFailIfEmptyContentCollectionIsAdded()
+    {
+        $this->createBaseMailConfig()
+             ->addContents(new ContentCollection);
+    }
+
+    /**
+     * Library should be strict and Mail should always be in a valid state,
+     * therefore, if we try to add an empty collection it should throw an exception
+     *
+     * @return void
+     * @test
+     * @expectedException \SendGrid\Mail\Optional\Exception\SectionCollectionIsEmptyException
+     */
+    public function itShouldFailIfEmptySectionCollectionIsAdded()
+    {
+        $this->createBaseMailConfig()
+             ->addSections(new SectionCollection);
+    }
+
+    /**
+     * Library should be strict and Mail should always be in a valid state,
+     * therefore, if we try to add an empty collection it should throw an exception
+     *
+     * @return void
+     * @test
+     * @expectedException \SendGrid\Mail\Optional\Exception\HeaderCollectionIsEmptyException
+     */
+    public function itShouldFailIfEmptyHeaderCollectionIsAdded()
+    {
+        $this->createBaseMailConfig()
+             ->addHeaders(new HeaderCollection);
+    }
+
+    /**
+     * Library should be strict and Mail should always be in a valid state,
+     * therefore, if we try to add an empty collection it should throw an exception
+     *
+     * @return void
+     * @test
+     * @expectedException \SendGrid\Mail\Optional\Exception\CategoryCollectionIsEmptyException
+     */
+    public function itShouldFailIfEmptyCategoryCollectionIsAdded()
+    {
+        $this->createBaseMailConfig()
+             ->addCategories(new CategoryCollection);
+    }
+
+    /**
+     * Library should be strict and Mail should always be in a valid state,
+     * therefore, if we try to add an empty collection it should throw an exception
+     *
+     * @return void
+     * @test
+     * @expectedException \SendGrid\Mail\Optional\Exception\CustomArgumentCollectionIsEmptyException
+     */
+    public function itShouldFailIfEmptyCustomArgumentCollectionIsAdded()
+    {
+        $this->createBaseMailConfig()
+             ->addCustomArguments(new CustomArgumentCollection);
+    }
+
+    /**
+     * Library should be strict and Mail should always be in a valid state,
+     * therefore, if we try to add an empty collection it should throw an exception
+     *
+     * @return void
+     * @test
+     * @expectedException \SendGrid\Mail\Optional\Exception\ReplyToCollectionIsEmptyException
+     */
+    public function itShouldFailIfEmptyReplyToCollectionIsAdded()
+    {
+        $this->createBaseMailConfig()
+             ->addRepliesTo(new ReplyToCollection);
+    }
+
+    /**
+     * Library should be strict and Mail should always be in a valid state,
+     * therefore, if we try to add empty settings it should throw an exception
+     *
+     * @return void
+     * @test
+     * @expectedException \SendGrid\Mail\Setting\Exception\MailSettingsIsEmptyException
+     */
+    public function itShouldFailIfEmptyMailSettingsIsAdded()
+    {
+        $this->createBaseMailConfig()
+             ->addMailSettings(new MailSettings);
+    }
+
+    /**
+     * Library should be strict and Mail should always be in a valid state,
+     * therefore, if we try to add empty settings it should throw an exception
+     *
+     * @return void
+     * @test
+     * @expectedException \SendGrid\Mail\Setting\Exception\TrackingSettingsIsEmptyException
+     */
+    public function itShouldFailIfEmptyTrackingSettingsIsAdded()
+    {
+        $this->createBaseMailConfig()
+             ->addTrackingSettings(new TrackingSettings);
+    }
+
+    /**
+     * @return Mail
+     */
+    private function createBaseMailConfig()
+    {
+        $from = new From('sendgrid@sendgrid.com', 'SendGrid PHP');
+        $subject = new Subject('Hello World from the SendGrid PHP Library');
+        $tos = new ToCollection([
+            new To("test@example.com", "Test User"),
+            new To('other@example.com', "Other Test User")
+        ]);
+        $content = new ContentCollection([
+            new Content('text/plain', 'some text here'),
+            new Content('text/html', '<html><body>some text here</body></html>')
+        ]);
+
+        return new Mail($from, $tos, $content, $subject);
+    }
+
+    /**
+     * @param $json
+     * @return string
+     */
+    private function getEncoded($json)
+    {
+        return json_encode(
+            json_decode($json)
+        );
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedBaseMailJson()
+    {
+        return <<<JSON
+        {
+           "from":{
+              "name":"SendGrid PHP",
+              "email":"sendgrid@sendgrid.com"
+           },
+           "personalizations":[
+              {
+                 "to":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "subject":"Hello World from the SendGrid PHP Library",
+                 "send_at":{$this->getSendAt()}
+              }
+           ],
+           "content":[
+              {
+                 "type":"text/plain",
+                 "value":"some text here"
+              },
+              {
+                 "type":"text/html",
+                 "value":"<html><body>some text here</body></html>"
+              }
+           ],
+           "subject":"Hello World from the SendGrid PHP Library"
+        }
+JSON;
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedCcJson()
+    {
+        return <<<JSON
+        {
+           "from":{
+              "name":"SendGrid PHP",
+              "email":"sendgrid@sendgrid.com"
+           },
+           "personalizations":[
+              {
+                 "to":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "cc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "subject":"Hello World from the SendGrid PHP Library",
+                 "send_at":{$this->getSendAt()}
+              }
+           ],
+           "content":[
+              {
+                 "type":"text/plain",
+                 "value":"some text here"
+              },
+              {
+                 "type":"text/html",
+                 "value":"<html><body>some text here</body></html>"
+              }
+           ],
+           "subject":"Hello World from the SendGrid PHP Library"
+        }
+JSON;
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedBccJson()
+    {
+        return <<<JSON
+        {
+           "from":{
+              "name":"SendGrid PHP",
+              "email":"sendgrid@sendgrid.com"
+           },
+           "personalizations":[
+              {
+                 "to":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "cc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "bcc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "subject":"Hello World from the SendGrid PHP Library",
+                 "send_at":{$this->getSendAt()}
+              }
+           ],
+           "content":[
+              {
+                 "type":"text/plain",
+                 "value":"some text here"
+              },
+              {
+                 "type":"text/html",
+                 "value":"<html><body>some text here</body></html>"
+              }
+           ],
+           "subject":"Hello World from the SendGrid PHP Library"
+        }
+JSON;
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedHeaderPersonalizationJson()
+    {
+        return <<<JSON
+        {
+           "from":{
+              "name":"SendGrid PHP",
+              "email":"sendgrid@sendgrid.com"
+           },
+           "personalizations":[
+              {
+                 "to":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "cc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "bcc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "subject":"Hello World from the SendGrid PHP Library",
+                 "headers":{
+                    "X-Test":"test",
+                    "X-Mock":"true"
+                 },
+                 "send_at":{$this->getSendAt()}
+              }
+           ],
+           "content":[
+              {
+                 "type":"text/plain",
+                 "value":"some text here"
+              },
+              {
+                 "type":"text/html",
+                 "value":"<html><body>some text here</body></html>"
+              }
+           ],
+           "subject":"Hello World from the SendGrid PHP Library"
+        }
+JSON;
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedSubstitutionJson()
+    {
+        return <<<JSON
+        {
+           "from":{
+              "name":"SendGrid PHP",
+              "email":"sendgrid@sendgrid.com"
+           },
+           "personalizations":[
+              {
+                 "to":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "cc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "bcc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "subject":"Hello World from the SendGrid PHP Library",
+                 "headers":{
+                    "X-Test":"test",
+                    "X-Mock":"true"
+                 },
+                 "substitutions":{
+                    "%name%":"Example User",
+                    "%city%":"Denver"
+                 },
+                 "send_at":{$this->getSendAt()}
+              }
+           ],
+           "content":[
+              {
+                 "type":"text/plain",
+                 "value":"some text here"
+              },
+              {
+                 "type":"text/html",
+                 "value":"<html><body>some text here</body></html>"
+              }
+           ],
+           "subject":"Hello World from the SendGrid PHP Library"
+        }
+JSON;
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedCustomArgumentPersonalization()
+    {
+        return <<<JSON
+        {
+           "from":{
+              "name":"SendGrid PHP",
+              "email":"sendgrid@sendgrid.com"
+           },
+           "personalizations":[
+              {
+                 "to":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "cc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "bcc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "subject":"Hello World from the SendGrid PHP Library",
+                 "headers":{
+                    "X-Test":"test",
+                    "X-Mock":"true"
+                 },
+                 "substitutions":{
+                    "%name%":"Example User",
+                    "%city%":"Denver"
+                 },
+                 "custom_args":{
+                    "user_id":"343",
+                    "type":"marketing"
+                 },
+                 "send_at":{$this->getSendAt()}
+              }
+           ],
+           "content":[
+              {
+                 "type":"text/plain",
+                 "value":"some text here"
+              },
+              {
+                 "type":"text/html",
+                 "value":"<html><body>some text here</body></html>"
+              }
+           ],
+           "subject":"Hello World from the SendGrid PHP Library"
+        }
+JSON;
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedAttachmentJson()
+    {
+        return <<<JSON
+        {
+           "from":{
+              "name":"SendGrid PHP",
+              "email":"sendgrid@sendgrid.com"
+           },
+           "personalizations":[
+              {
+                 "to":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "cc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "bcc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "subject":"Hello World from the SendGrid PHP Library",
+                 "headers":{
+                    "X-Test":"test",
+                    "X-Mock":"true"
+                 },
+                 "substitutions":{
+                    "%name%":"Example User",
+                    "%city%":"Denver"
+                 },
+                 "custom_args":{
+                    "user_id":"343",
+                    "type":"marketing"
+                 },
+                 "send_at":{$this->getSendAt()}
+              }
+           ],
+           "content":[
+              {
+                 "type":"text/plain",
+                 "value":"some text here"
+              },
+              {
+                 "type":"text/html",
+                 "value":"<html><body>some text here</body></html>"
+              }
+           ],
+           "subject":"Hello World from the SendGrid PHP Library",
+           "attachments":[
+              {
+                 "content":"content",
+                 "type":"type",
+                 "filename":"name",
+                 "disposition":"disposition",
+                 "content_id":"anId"
+              },
+              {
+                 "content":"otherContent",
+                 "type":"otherType",
+                 "filename":"otherName",
+                 "disposition":"otherDisposition",
+                 "content_id":"otherId"
+              }
+           ]
+        }
+JSON;
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedTemplateIdJson()
+    {
+        return <<<JSOn
+        {
+           "from":{
+              "name":"SendGrid PHP",
+              "email":"sendgrid@sendgrid.com"
+           },
+           "personalizations":[
+              {
+                 "to":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "cc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "bcc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "subject":"Hello World from the SendGrid PHP Library",
+                 "headers":{
+                    "X-Test":"test",
+                    "X-Mock":"true"
+                 },
+                 "substitutions":{
+                    "%name%":"Example User",
+                    "%city%":"Denver"
+                 },
+                 "custom_args":{
+                    "user_id":"343",
+                    "type":"marketing"
+                 },
+                 "send_at":{$this->getSendAt()}
+              }
+           ],
+           "content":[
+              {
+                 "type":"text/plain",
+                 "value":"some text here"
+              },
+              {
+                 "type":"text/html",
+                 "value":"<html><body>some text here</body></html>"
+              }
+           ],
+           "subject":"Hello World from the SendGrid PHP Library",
+           "attachments":[
+              {
+                 "content":"content",
+                 "type":"type",
+                 "filename":"name",
+                 "disposition":"disposition",
+                 "content_id":"anId"
+              },
+              {
+                 "content":"otherContent",
+                 "type":"otherType",
+                 "filename":"otherName",
+                 "disposition":"otherDisposition",
+                 "content_id":"otherId"
+              }
+           ],
+           "template_id":"439b6d66-4408-4ead-83de-5c83c2ee313a"
+        }
+JSOn;
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedSectionJson()
+    {
+        return <<<JSON
+        {
+           "from":{
+              "name":"SendGrid PHP",
+              "email":"sendgrid@sendgrid.com"
+           },
+           "personalizations":[
+              {
+                 "to":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "cc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "bcc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "subject":"Hello World from the SendGrid PHP Library",
+                 "headers":{
+                    "X-Test":"test",
+                    "X-Mock":"true"
+                 },
+                 "substitutions":{
+                    "%name%":"Example User",
+                    "%city%":"Denver"
+                 },
+                 "custom_args":{
+                    "user_id":"343",
+                    "type":"marketing"
+                 },
+                 "send_at":{$this->getSendAt()}
+              }
+           ],
+           "content":[
+              {
+                 "type":"text/plain",
+                 "value":"some text here"
+              },
+              {
+                 "type":"text/html",
+                 "value":"<html><body>some text here</body></html>"
+              }
+           ],
+           "subject":"Hello World from the SendGrid PHP Library",
+           "attachments":[
+              {
+                 "content":"content",
+                 "type":"type",
+                 "filename":"name",
+                 "disposition":"disposition",
+                 "content_id":"anId"
+              },
+              {
+                 "content":"otherContent",
+                 "type":"otherType",
+                 "filename":"otherName",
+                 "disposition":"otherDisposition",
+                 "content_id":"otherId"
+              }
+           ],
+           "template_id":"439b6d66-4408-4ead-83de-5c83c2ee313a",
+           "sections":{
+              "%section1%":"Substitution Text for Section 2"
+           }
+        }
+JSON;
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedHeaderJson()
+    {
+        return <<<JSON
+        {
+           "from":{
+              "name":"SendGrid PHP",
+              "email":"sendgrid@sendgrid.com"
+           },
+           "personalizations":[
+              {
+                 "to":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "cc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "bcc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "subject":"Hello World from the SendGrid PHP Library",
+                 "headers":{
+                    "X-Test":"test",
+                    "X-Mock":"true"
+                 },
+                 "substitutions":{
+                    "%name%":"Example User",
+                    "%city%":"Denver"
+                 },
+                 "custom_args":{
+                    "user_id":"343",
+                    "type":"marketing"
+                 },
+                 "send_at":{$this->getSendAt()}
+              }
+           ],
+           "content":[
+              {
+                 "type":"text/plain",
+                 "value":"some text here"
+              },
+              {
+                 "type":"text/html",
+                 "value":"<html><body>some text here</body></html>"
+              }
+           ],
+           "subject":"Hello World from the SendGrid PHP Library",
+           "attachments":[
+              {
+                 "content":"content",
+                 "type":"type",
+                 "filename":"name",
+                 "disposition":"disposition",
+                 "content_id":"anId"
+              },
+              {
+                 "content":"otherContent",
+                 "type":"otherType",
+                 "filename":"otherName",
+                 "disposition":"otherDisposition",
+                 "content_id":"otherId"
+              }
+           ],
+           "template_id":"439b6d66-4408-4ead-83de-5c83c2ee313a",
+           "sections":{
+              "%section1%":"Substitution Text for Section 2"
+           },
+           "headers":{
+              "X-Test1":"1",
+              "X-Test2":"2"
+           }
+        }
+JSON;
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedCategoryJson()
+    {
+        return <<<JSON
+        {
+           "from":{
+              "name":"SendGrid PHP",
+              "email":"sendgrid@sendgrid.com"
+           },
+           "personalizations":[
+              {
+                 "to":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "cc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "bcc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "subject":"Hello World from the SendGrid PHP Library",
+                 "headers":{
+                    "X-Test":"test",
+                    "X-Mock":"true"
+                 },
+                 "substitutions":{
+                    "%name%":"Example User",
+                    "%city%":"Denver"
+                 },
+                 "custom_args":{
+                    "user_id":"343",
+                    "type":"marketing"
+                 },
+                 "send_at":{$this->getSendAt()}
+              }
+           ],
+           "content":[
+              {
+                 "type":"text/plain",
+                 "value":"some text here"
+              },
+              {
+                 "type":"text\/html",
+                 "value":"<html><body>some text here</body></html>"
+              }
+           ],
+           "subject":"Hello World from the SendGrid PHP Library",
+           "attachments":[
+              {
+                 "content":"content",
+                 "type":"type",
+                 "filename":"name",
+                 "disposition":"disposition",
+                 "content_id":"anId"
+              },
+              {
+                 "content":"otherContent",
+                 "type":"otherType",
+                 "filename":"otherName",
+                 "disposition":"otherDisposition",
+                 "content_id":"otherId"
+              }
+           ],
+           "template_id":"439b6d66-4408-4ead-83de-5c83c2ee313a",
+           "sections":{
+              "%section1%":"Substitution Text for Section 2"
+           },
+           "headers":{
+              "X-Test1":"1",
+              "X-Test2":"2"
+           },
+           "categories":[
+              "May",
+              "2016"
+           ]
+        }
+JSON;
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedCustomArgumentJson()
+    {
+        return <<<JSON
+        {
+           "from":{
+              "name":"SendGrid PHP",
+              "email":"sendgrid@sendgrid.com"
+           },
+           "personalizations":[
+              {
+                 "to":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "cc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "bcc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "subject":"Hello World from the SendGrid PHP Library",
+                 "headers":{
+                    "X-Test":"test",
+                    "X-Mock":"true"
+                 },
+                 "substitutions":{
+                    "%name%":"Example User",
+                    "%city%":"Denver"
+                 },
+                 "custom_args":{
+                    "user_id":"343",
+                    "type":"marketing"
+                 },
+                 "send_at":{$this->getSendAt()}
+              }
+           ],
+           "content":[
+              {
+                 "type":"text/plain",
+                 "value":"some text here"
+              },
+              {
+                 "type":"text\/html",
+                 "value":"<html><body>some text here</body></html>"
+              }
+           ],
+           "subject":"Hello World from the SendGrid PHP Library",
+           "attachments":[
+              {
+                 "content":"content",
+                 "type":"type",
+                 "filename":"name",
+                 "disposition":"disposition",
+                 "content_id":"anId"
+              },
+              {
+                 "content":"otherContent",
+                 "type":"otherType",
+                 "filename":"otherName",
+                 "disposition":"otherDisposition",
+                 "content_id":"otherId"
+              }
+           ],
+           "template_id":"439b6d66-4408-4ead-83de-5c83c2ee313a",
+           "sections":{
+              "%section1%":"Substitution Text for Section 2"
+           },
+           "headers":{
+              "X-Test1":"1",
+              "X-Test2":"2"
+           },
+           "categories":[
+              "May",
+              "2016"
+           ],
+           "custom_args":{
+              "campaign":"welcome",
+              "weekday":"morning"
+           }
+        }
+JSON;
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedAsmJson()
+    {
+        return <<<JSON
+        {
+           "from":{
+              "name":"SendGrid PHP",
+              "email":"sendgrid@sendgrid.com"
+           },
+           "personalizations":[
+              {
+                 "to":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "cc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "bcc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "subject":"Hello World from the SendGrid PHP Library",
+                 "headers":{
+                    "X-Test":"test",
+                    "X-Mock":"true"
+                 },
+                 "substitutions":{
+                    "%name%":"Example User",
+                    "%city%":"Denver"
+                 },
+                 "custom_args":{
+                    "user_id":"343",
+                    "type":"marketing"
+                 },
+                 "send_at":{$this->getSendAt()}
+              }
+           ],
+           "content":[
+              {
+                 "type":"text/plain",
+                 "value":"some text here"
+              },
+              {
+                 "type":"text/html",
+                 "value":"<html><body>some text here</body></html>"
+              }
+           ],
+           "subject":"Hello World from the SendGrid PHP Library",
+           "attachments":[
+              {
+                 "content":"content",
+                 "type":"type",
+                 "filename":"name",
+                 "disposition":"disposition",
+                 "content_id":"anId"
+              },
+              {
+                 "content":"otherContent",
+                 "type":"otherType",
+                 "filename":"otherName",
+                 "disposition":"otherDisposition",
+                 "content_id":"otherId"
+              }
+           ],
+           "template_id":"439b6d66-4408-4ead-83de-5c83c2ee313a",
+           "sections":{
+              "%section1%":"Substitution Text for Section 2"
+           },
+           "headers":{
+              "X-Test1":"1",
+              "X-Test2":"2"
+           },
+           "categories":[
+              "May",
+              "2016"
+           ],
+           "custom_args":{
+              "campaign":"welcome",
+              "weekday":"morning"
+           },
+           "asm":{
+              "group_id":99,
+              "groups_to_display":[
+                 4,
+                 5,
+                 6,
+                 7,
+                 8
+              ]
+           }
+        }
+JSON;
+    }
+
+
+    private function getExpectedIpPoolNameJson()
+    {
+        return <<<JSON
+        {
+           "from":{
+              "name":"SendGrid PHP",
+              "email":"sendgrid@sendgrid.com"
+           },
+           "personalizations":[
+              {
+                 "to":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "cc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "bcc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "subject":"Hello World from the SendGrid PHP Library",
+                 "headers":{
+                    "X-Test":"test",
+                    "X-Mock":"true"
+                 },
+                 "substitutions":{
+                    "%name%":"Example User",
+                    "%city%":"Denver"
+                 },
+                 "custom_args":{
+                    "user_id":"343",
+                    "type":"marketing"
+                 },
+                 "send_at":{$this->getSendAt()}
+              }
+           ],
+           "content":[
+              {
+                 "type":"text/plain",
+                 "value":"some text here"
+              },
+              {
+                 "type":"text/html",
+                 "value":"<html><body>some text here</body></html>"
+              }
+           ],
+           "subject":"Hello World from the SendGrid PHP Library",
+           "attachments":[
+              {
+                 "content":"content",
+                 "type":"type",
+                 "filename":"name",
+                 "disposition":"disposition",
+                 "content_id":"anId"
+              },
+              {
+                 "content":"otherContent",
+                 "type":"otherType",
+                 "filename":"otherName",
+                 "disposition":"otherDisposition",
+                 "content_id":"otherId"
+              }
+           ],
+           "template_id":"439b6d66-4408-4ead-83de-5c83c2ee313a",
+           "sections":{
+              "%section1%":"Substitution Text for Section 2"
+           },
+           "headers":{
+              "X-Test1":"1",
+              "X-Test2":"2"
+           },
+           "categories":[
+              "May",
+              "2016"
+           ],
+           "custom_args":{
+              "campaign":"welcome",
+              "weekday":"morning"
+           },
+           "asm":{
+              "group_id":99,
+              "groups_to_display":[
+                 4,
+                 5,
+                 6,
+                 7,
+                 8
+              ]
+           },
+           "ip_pool_name":"23"
+        }
+JSON;
+    }
+
+    /**
+     * @return string
+     */
+    public function getExpectedBccSettingsJson()
+    {
+        return <<<JSON
+        {
+           "from":{
+              "name":"SendGrid PHP",
+              "email":"sendgrid@sendgrid.com"
+           },
+           "personalizations":[
+              {
+                 "to":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "cc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "bcc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "subject":"Hello World from the SendGrid PHP Library",
+                 "headers":{
+                    "X-Test":"test",
+                    "X-Mock":"true"
+                 },
+                 "substitutions":{
+                    "%name%":"Example User",
+                    "%city%":"Denver"
+                 },
+                 "custom_args":{
+                    "user_id":"343",
+                    "type":"marketing"
+                 },
+                 "send_at":{$this->getSendAt()}
+              }
+           ],
+           "content":[
+              {
+                 "type":"text\/plain",
+                 "value":"some text here"
+              },
+              {
+                 "type":"text/html",
+                 "value":"<html><body>some text here</body></html>"
+              }
+           ],
+           "subject":"Hello World from the SendGrid PHP Library",
+           "attachments":[
+              {
+                 "content":"content",
+                 "type":"type",
+                 "filename":"name",
+                 "disposition":"disposition",
+                 "content_id":"anId"
+              },
+              {
+                 "content":"otherContent",
+                 "type":"otherType",
+                 "filename":"otherName",
+                 "disposition":"otherDisposition",
+                 "content_id":"otherId"
+              }
+           ],
+           "template_id":"439b6d66-4408-4ead-83de-5c83c2ee313a",
+           "sections":{
+              "%section1%":"Substitution Text for Section 2"
+           },
+           "headers":{
+              "X-Test1":"1",
+              "X-Test2":"2"
+           },
+           "categories":[
+              "May",
+              "2016"
+           ],
+           "custom_args":{
+              "campaign":"welcome",
+              "weekday":"morning"
+           },
+           "asm":{
+              "group_id":99,
+              "groups_to_display":[
+                 4,
+                 5,
+                 6,
+                 7,
+                 8
+              ]
+           },
+           "ip_pool_name":"23",
+           "mail_settings":{
+              "bcc":{
+                 "enable":true,
+                 "email":"test@example.com"
+              }
+           }
+        }
+JSON;
+    }
+
+    /**
+     * @return string
+     */
+    public function getExpectedByPassListManagementJson()
+    {
+        return <<<JSON
+        {
+           "from":{
+              "name":"SendGrid PHP",
+              "email":"sendgrid@sendgrid.com"
+           },
+           "personalizations":[
+              {
+                 "to":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "cc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "bcc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "subject":"Hello World from the SendGrid PHP Library",
+                 "headers":{
+                    "X-Test":"test",
+                    "X-Mock":"true"
+                 },
+                 "substitutions":{
+                    "%name%":"Example User",
+                    "%city%":"Denver"
+                 },
+                 "custom_args":{
+                    "user_id":"343",
+                    "type":"marketing"
+                 },
+                 "send_at":{$this->getSendAt()}
+              }
+           ],
+           "content":[
+              {
+                 "type":"text\/plain",
+                 "value":"some text here"
+              },
+              {
+                 "type":"text/html",
+                 "value":"<html><body>some text here</body></html>"
+              }
+           ],
+           "subject":"Hello World from the SendGrid PHP Library",
+           "attachments":[
+              {
+                 "content":"content",
+                 "type":"type",
+                 "filename":"name",
+                 "disposition":"disposition",
+                 "content_id":"anId"
+              },
+              {
+                 "content":"otherContent",
+                 "type":"otherType",
+                 "filename":"otherName",
+                 "disposition":"otherDisposition",
+                 "content_id":"otherId"
+              }
+           ],
+           "template_id":"439b6d66-4408-4ead-83de-5c83c2ee313a",
+           "sections":{
+              "%section1%":"Substitution Text for Section 2"
+           },
+           "headers":{
+              "X-Test1":"1",
+              "X-Test2":"2"
+           },
+           "categories":[
+              "May",
+              "2016"
+           ],
+           "custom_args":{
+              "campaign":"welcome",
+              "weekday":"morning"
+           },
+           "asm":{
+              "group_id":99,
+              "groups_to_display":[
+                 4,
+                 5,
+                 6,
+                 7,
+                 8
+              ]
+           },
+           "ip_pool_name":"23",
+           "mail_settings":{
+              "bcc":{
+                 "enable":true,
+                 "email":"test@example.com"
+              },
+              "bypass_list_management":{
+                 "enable":true
+              }
+           }
+        }
+JSON;
+    }
+
+    /**
+     * @return string
+     */
+    public function getExpectedFooterJson()
+    {
+        return <<<JSON
+        {
+           "from":{
+              "name":"SendGrid PHP",
+              "email":"sendgrid@sendgrid.com"
+           },
+           "personalizations":[
+              {
+                 "to":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "cc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "bcc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "subject":"Hello World from the SendGrid PHP Library",
+                 "headers":{
+                    "X-Test":"test",
+                    "X-Mock":"true"
+                 },
+                 "substitutions":{
+                    "%name%":"Example User",
+                    "%city%":"Denver"
+                 },
+                 "custom_args":{
+                    "user_id":"343",
+                    "type":"marketing"
+                 },
+                 "send_at":{$this->getSendAt()}
+              }
+           ],
+           "content":[
+              {
+                 "type":"text/plain",
+                 "value":"some text here"
+              },
+              {
+                 "type":"text/html",
+                 "value":"<html><body>some text here</body></html>"
+              }
+           ],
+           "subject":"Hello World from the SendGrid PHP Library",
+           "attachments":[
+              {
+                 "content":"content",
+                 "type":"type",
+                 "filename":"name",
+                 "disposition":"disposition",
+                 "content_id":"anId"
+              },
+              {
+                 "content":"otherContent",
+                 "type":"otherType",
+                 "filename":"otherName",
+                 "disposition":"otherDisposition",
+                 "content_id":"otherId"
+              }
+           ],
+           "template_id":"439b6d66-4408-4ead-83de-5c83c2ee313a",
+           "sections":{
+              "%section1%":"Substitution Text for Section 2"
+           },
+           "headers":{
+              "X-Test1":"1",
+              "X-Test2":"2"
+           },
+           "categories":[
+              "May",
+              "2016"
+           ],
+           "custom_args":{
+              "campaign":"welcome",
+              "weekday":"morning"
+           },
+           "asm":{
+              "group_id":99,
+              "groups_to_display":[
+                 4,
+                 5,
+                 6,
+                 7,
+                 8
+              ]
+           },
+           "ip_pool_name":"23",
+           "mail_settings":{
+              "bcc":{
+                 "enable":true,
+                 "email":"test@example.com"
+              },
+              "bypass_list_management":{
+                 "enable":true
+              },
+              "footer":{
+                 "enable":true,
+                 "text":"Footer Text",
+                 "html":"<html><body>Footer Text</body></html>"
+              }
+           }
+        }
+JSON;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSandBoxModeExpectedJson()
+    {
+        return <<<JSON
+        {
+           "from":{
+              "name":"SendGrid PHP",
+              "email":"sendgrid@sendgrid.com"
+           },
+           "personalizations":[
+              {
+                 "to":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "cc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "bcc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "subject":"Hello World from the SendGrid PHP Library",
+                 "headers":{
+                    "X-Test":"test",
+                    "X-Mock":"true"
+                 },
+                 "substitutions":{
+                    "%name%":"Example User",
+                    "%city%":"Denver"
+                 },
+                 "custom_args":{
+                    "user_id":"343",
+                    "type":"marketing"
+                 },
+                 "send_at":{$this->getSendAt()}
+              }
+           ],
+           "content":[
+              {
+                 "type":"text/plain",
+                 "value":"some text here"
+              },
+              {
+                 "type":"text\/html",
+                 "value":"<html><body>some text here</body></html>"
+              }
+           ],
+           "subject":"Hello World from the SendGrid PHP Library",
+           "attachments":[
+              {
+                 "content":"content",
+                 "type":"type",
+                 "filename":"name",
+                 "disposition":"disposition",
+                 "content_id":"anId"
+              },
+              {
+                 "content":"otherContent",
+                 "type":"otherType",
+                 "filename":"otherName",
+                 "disposition":"otherDisposition",
+                 "content_id":"otherId"
+              }
+           ],
+           "template_id":"439b6d66-4408-4ead-83de-5c83c2ee313a",
+           "sections":{
+              "%section1%":"Substitution Text for Section 2"
+           },
+           "headers":{
+              "X-Test1":"1",
+              "X-Test2":"2"
+           },
+           "categories":[
+              "May",
+              "2016"
+           ],
+           "custom_args":{
+              "campaign":"welcome",
+              "weekday":"morning"
+           },
+           "asm":{
+              "group_id":99,
+              "groups_to_display":[
+                 4,
+                 5,
+                 6,
+                 7,
+                 8
+              ]
+           },
+           "ip_pool_name":"23",
+           "mail_settings":{
+              "bcc":{
+                 "enable":true,
+                 "email":"test@example.com"
+              },
+              "bypass_list_management":{
+                 "enable":true
+              },
+              "footer":{
+                 "enable":true,
+                 "text":"Footer Text",
+                 "html":"<html><body>Footer Text</body></html>"
+              },
+              "sandbox_mode":{
+                 "enable":true
+              }
+           }
+        }
+JSON;
+    }
+
+    /**
+     * @return string
+     */
+    public function getExpectedSpamCheckJson()
+    {
+        return <<<JSON
+        {
+           "from":{
+              "name":"SendGrid PHP",
+              "email":"sendgrid@sendgrid.com"
+           },
+           "personalizations":[
+              {
+                 "to":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "cc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "bcc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "subject":"Hello World from the SendGrid PHP Library",
+                 "headers":{
+                    "X-Test":"test",
+                    "X-Mock":"true"
+                 },
+                 "substitutions":{
+                    "%name%":"Example User",
+                    "%city%":"Denver"
+                 },
+                 "custom_args":{
+                    "user_id":"343",
+                    "type":"marketing"
+                 },
+                 "send_at":{$this->getSendAt()}
+              }
+           ],
+           "content":[
+              {
+                 "type":"text/plain",
+                 "value":"some text here"
+              },
+              {
+                 "type":"text/html",
+                 "value":"<html><body>some text here</body></html>"
+              }
+           ],
+           "subject":"Hello World from the SendGrid PHP Library",
+           "attachments":[
+              {
+                 "content":"content",
+                 "type":"type",
+                 "filename":"name",
+                 "disposition":"disposition",
+                 "content_id":"anId"
+              },
+              {
+                 "content":"otherContent",
+                 "type":"otherType",
+                 "filename":"otherName",
+                 "disposition":"otherDisposition",
+                 "content_id":"otherId"
+              }
+           ],
+           "template_id":"439b6d66-4408-4ead-83de-5c83c2ee313a",
+           "sections":{
+              "%section1%":"Substitution Text for Section 2"
+           },
+           "headers":{
+              "X-Test1":"1",
+              "X-Test2":"2"
+           },
+           "categories":[
+              "May",
+              "2016"
+           ],
+           "custom_args":{
+              "campaign":"welcome",
+              "weekday":"morning"
+           },
+           "asm":{
+              "group_id":99,
+              "groups_to_display":[
+                 4,
+                 5,
+                 6,
+                 7,
+                 8
+              ]
+           },
+           "ip_pool_name":"23",
+           "mail_settings":{
+              "bcc":{
+                 "enable":true,
+                 "email":"test@example.com"
+              },
+              "bypass_list_management":{
+                 "enable":true
+              },
+              "footer":{
+                 "enable":true,
+                 "text":"Footer Text",
+                 "html":"<html><body>Footer Text</body></html>"
+              },
+              "sandbox_mode":{
+                 "enable":true
+              },
+              "spam_check":{
+                 "enable":true,
+                 "threshold":1,
+                 "post_to_url":"https://spamcatcher.sendgrid.com"
+              }
+           }
+        }
+JSON;
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedTrackingSettingsJson()
+    {
+        return <<<JSON
+        {
+           "from":{
+              "name":"SendGrid PHP",
+              "email":"sendgrid@sendgrid.com"
+           },
+           "personalizations":[
+              {
+                 "to":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "cc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "bcc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "subject":"Hello World from the SendGrid PHP Library",
+                 "headers":{
+                    "X-Test":"test",
+                    "X-Mock":"true"
+                 },
+                 "substitutions":{
+                    "%name%":"Example User",
+                    "%city%":"Denver"
+                 },
+                 "custom_args":{
+                    "user_id":"343",
+                    "type":"marketing"
+                 },
+                 "send_at":{$this->getSendAt()}
+              }
+           ],
+           "content":[
+              {
+                 "type":"text/plain",
+                 "value":"some text here"
+              },
+              {
+                 "type":"text/html",
+                 "value":"<html><body>some text here</body></html>"
+              }
+           ],
+           "subject":"Hello World from the SendGrid PHP Library",
+           "attachments":[
+              {
+                 "content":"content",
+                 "type":"type",
+                 "filename":"name",
+                 "disposition":"disposition",
+                 "content_id":"anId"
+              },
+              {
+                 "content":"otherContent",
+                 "type":"otherType",
+                 "filename":"otherName",
+                 "disposition":"otherDisposition",
+                 "content_id":"otherId"
+              }
+           ],
+           "template_id":"439b6d66-4408-4ead-83de-5c83c2ee313a",
+           "sections":{
+              "%section1%":"Substitution Text for Section 2"
+           },
+           "headers":{
+              "X-Test1":"1",
+              "X-Test2":"2"
+           },
+           "categories":[
+              "May",
+              "2016"
+           ],
+           "custom_args":{
+              "campaign":"welcome",
+              "weekday":"morning"
+           },
+           "asm":{
+              "group_id":99,
+              "groups_to_display":[
+                 4,
+                 5,
+                 6,
+                 7,
+                 8
+              ]
+           },
+           "ip_pool_name":"23",
+           "mail_settings":{
+              "bcc":{
+                 "enable":true,
+                 "email":"test@example.com"
+              },
+              "bypass_list_management":{
+                 "enable":true
+              },
+              "footer":{
+                 "enable":true,
+                 "text":"Footer Text",
+                 "html":"<html><body>Footer Text</body></html>"
+              },
+              "sandbox_mode":{
+                 "enable":true
+              },
+              "spam_check":{
+                 "enable":true,
+                 "threshold":1,
+                 "post_to_url":"https://spamcatcher.sendgrid.com"
+              }
+           },
+           "tracking_settings":{
+              "click_tracking":{
+                 "enable":true,
+                 "enable_text":true
+              },
+              "open_tracking":{
+                 "enable":true,
+                 "substitution_tag":"Optional tag to replace"
+              },
+              "subscription_tracking":{
+                 "enable":true,
+                 "text":"text to insert into the text/plain portion of the message",
+                 "html":"<html><body>html to insert into the text/html portion of the message</body></html>",
+                 "substitution_tag":"Optional tag to replace with the open image in the body of the message"
+              },
+              "ganalytics":{
+                 "enable":true,
+                 "utm_source":"source",
+                 "utm_medium":"medium",
+                 "utm_term":"term",
+                 "utm_content":"content",
+                 "utm_campaign":"content"
+              }
+           }
+        }
+JSON;
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedRepliesToJson()
+    {
+        return <<<JSON
+        {
+           "from":{
+              "name":"SendGrid PHP",
+              "email":"sendgrid@sendgrid.com"
+           },
+           "personalizations":[
+              {
+                 "to":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "cc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "bcc":[
+                    {
+                       "name":"Test User",
+                       "email":"test@example.com"
+                    },
+                    {
+                       "name":"Other Test User",
+                       "email":"other@example.com"
+                    }
+                 ],
+                 "subject":"Hello World from the SendGrid PHP Library",
+                 "headers":{
+                    "X-Test":"test",
+                    "X-Mock":"true"
+                 },
+                 "substitutions":{
+                    "%name%":"Example User",
+                    "%city%":"Denver"
+                 },
+                 "custom_args":{
+                    "user_id":"343",
+                    "type":"marketing"
+                 },
+                 "send_at":{$this->getSendAt()}
+              }
+           ],
+           "content":[
+              {
+                 "type":"text\/plain",
+                 "value":"some text here"
+              },
+              {
+                 "type":"text/html",
+                 "value":"<html><body>some text here</body></html>"
+              }
+           ],
+           "subject":"Hello World from the SendGrid PHP Library",
+           "attachments":[
+              {
+                 "content":"content",
+                 "type":"type",
+                 "filename":"name",
+                 "disposition":"disposition",
+                 "content_id":"anId"
+              },
+              {
+                 "content":"otherContent",
+                 "type":"otherType",
+                 "filename":"otherName",
+                 "disposition":"otherDisposition",
+                 "content_id":"otherId"
+              }
+           ],
+           "template_id":"439b6d66-4408-4ead-83de-5c83c2ee313a",
+           "sections":{
+              "%section1%":"Substitution Text for Section 2"
+           },
+           "headers":{
+              "X-Test1":"1",
+              "X-Test2":"2"
+           },
+           "categories":[
+              "May",
+              "2016"
+           ],
+           "custom_args":{
+              "campaign":"welcome",
+              "weekday":"morning"
+           },
+           "asm":{
+              "group_id":99,
+              "groups_to_display":[
+                 4,
+                 5,
+                 6,
+                 7,
+                 8
+              ]
+           },
+           "ip_pool_name":"23",
+           "mail_settings":{
+              "bcc":{
+                 "enable":true,
+                 "email":"test@example.com"
+              },
+              "bypass_list_management":{
+                 "enable":true
+              },
+              "footer":{
+                 "enable":true,
+                 "text":"Footer Text",
+                 "html":"<html><body>Footer Text</body></html>"
+              },
+              "sandbox_mode":{
+                 "enable":true
+              },
+              "spam_check":{
+                 "enable":true,
+                 "threshold":1,
+                 "post_to_url":"https://spamcatcher.sendgrid.com"
+              }
+           },
+           "tracking_settings":{
+              "click_tracking":{
+                 "enable":true,
+                 "enable_text":true
+              },
+              "open_tracking":{
+                 "enable":true,
+                 "substitution_tag":"Optional tag to replace"
+              },
+              "subscription_tracking":{
+                 "enable":true,
+                 "text":"text to insert into the text/plain portion of the message",
+                 "html":"<html><body>html to insert into the text/html portion of the message</body></html>",
+                 "substitution_tag":"Optional tag to replace with the open image in the body of the message"
+              },
+              "ganalytics":{
+                 "enable":true,
+                 "utm_source":"source",
+                 "utm_medium":"medium",
+                 "utm_term":"term",
+                 "utm_content":"content",
+                 "utm_campaign":"content"
+              }
+           },
+           "reply_to":[
+              {
+                 "email":"test@example.com"
+              },
+              {
+                 "email":"other@example.com"
+              },
+              {
+                 "email":"last@example.com"
+              }
+           ]
+        }
+JSON;
+    }
+
+    /**
+     * @return false|int
+     */
+    private function getSendAt()
+    {
+        return strtotime((new \DateTime)->format('Y-m-d H:i:s'));
+    }
+}

--- a/tests/Mail/Setting/MailSettingsTest.php
+++ b/tests/Mail/Setting/MailSettingsTest.php
@@ -1,0 +1,293 @@
+<?php
+
+namespace Test\Mail\Setting;
+
+use SendGrid\Mail\Setting\Footer;
+use SendGrid\Mail\Setting\SpamCheck;
+use SendGrid\Mail\Setting\SandBoxMode;
+use SendGrid\Mail\Setting\BccSettings;
+use SendGrid\Mail\Setting\MailSettings;
+use SendGrid\Mail\ValueObject\EmailAddress;
+use SendGrid\Mail\Setting\ByPassListManagement;
+
+final class MailSettingsTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @return void
+     * @test
+     */
+    public function itShouldSerializeSuccessfully()
+    {
+        $settings = new MailSettings;
+        $this->assertTrue($settings->isEmpty());
+        $this->assertSame('null', json_encode($settings));
+
+        $settings->addBcc(
+            new BccSettings(true, new EmailAddress('test@example.com'))
+        );
+        $this->assertFalse($settings->isEmpty());
+        $this->assertSame(
+            json_encode($settings),
+            $this->getEncoded($this->getExpectedBccJson())
+        );
+
+        $settings->addByPassListManagement(
+            new ByPassListManagement(true)
+        );
+        $this->assertSame(
+            json_encode($settings),
+            $this->getEncoded($this->getExpectedByPassListManagementJson())
+        );
+
+        $settings->addFooter(
+            new Footer(true, 'Footer Text', '<html><body>Footer Text</body></html>')
+        );
+        $this->assertSame(
+            json_encode($settings),
+            $this->getEncoded($this->getExpectedFooterJson())
+        );
+
+        $settings->addSandBoxMode(new SandBoxMode(true));
+        $this->assertSame(
+            json_encode($settings),
+            $this->getEncoded($this->getExpectedSandBoxModeJson())
+        );
+
+        $settings->addSpamCheck(new SpamCheck(true, 1, 'https://spamcatcher.sendgrid.com'));
+        $this->assertSame(
+            json_encode($settings),
+            $this->getEncoded($this->getExpectedSpamCheckJson())
+        );
+    }
+
+    /**
+     * Our objects should be immutable, by allowing the user to change its state
+     * when ever a setter method is called is a bad practice, since we don't know
+     * which settings the user need, we protect our properties by don't allowing the user
+     * call the method twice, this way we can be sure that our objects are immutable.
+     *
+     * @return void
+     * @test
+     * @expectedException \SendGrid\Mail\Setting\Exception\BccSettingIsAlreadySetException
+     */
+    public function itShouldFailIfUserTriesToAddBccSettingTwice()
+    {
+        $settings = new MailSettings;
+        $settings->addBcc(
+            new BccSettings(true, new EmailAddress('test@example.com'))
+        );
+        $settings->addBcc(
+            new BccSettings(true, new EmailAddress('it_should_fail@fail.com'))
+        );
+    }
+
+    /**
+     * Our objects should be immutable, by allowing the user to change its state
+     * when ever a setter method is called is a bad practice, since we don't know
+     * which settings the user need, we protect our properties by don't allowing the user
+     * call the method twice, this way we can be sure that our objects are immutable.
+     *
+     * @return void
+     * @test
+     * @expectedException \SendGrid\Mail\Setting\Exception\ByPassListManagementSettingIsAlreadySetException
+     */
+    public function itShouldFailIfUserTriesToAddByPassListManagementSettingTwice()
+    {
+        $settings = new MailSettings;
+        $settings->addByPassListManagement(
+            new ByPassListManagement(true)
+        );
+        /** I'm trying to break immutability but it won't work :-( */
+        $settings->addByPassListManagement(
+            new ByPassListManagement(true)
+        );
+    }
+
+    /**
+     * Our objects should be immutable, by allowing the user to change its state
+     * when ever a setter method is called is a bad practice, since we don't know
+     * which settings the user need, we protect our properties by don't allowing the user
+     * call the method twice, this way we can be sure that our objects are immutable.
+     *
+     * @return void
+     * @test
+     * @expectedException \SendGrid\Mail\Setting\Exception\FooterSettingIsAlreadySetException
+     */
+    public function itShouldFailIfUserTriesToAddFooterSettingTwice()
+    {
+        $settings = new MailSettings;
+        $settings->addFooter(
+            new Footer(true, 'Footer Text', '<html><body>Footer Text</body></html>')
+        );
+        $settings->addFooter(
+            new Footer(true, 'I should not break immutability', '<html><body>Text</body></html>')
+        );
+    }
+
+    /**
+     * Our objects should be immutable, by allowing the user to change its state
+     * when ever a setter method is called is a bad practice, since we don't know
+     * which settings the user need, we protect our properties by don't allowing the user
+     * call the method twice, this way we can be sure that our objects are immutable.
+     *
+     * @return void
+     * @test
+     * @expectedException \SendGrid\Mail\Setting\Exception\SandBoxModeSettingIsAlreadySetException
+     */
+    public function itShouldFailIfUserTriesToAddSandBoxModeSettingTwice()
+    {
+        $settings = new MailSettings;
+        $settings->addSandBoxMode(
+            new SandBoxMode(true)
+        );
+        /** I'm trying to break immutability but it won't work :-( */
+        $settings->addSandBoxMode(
+            new SandBoxMode(false)
+        );
+    }
+
+    /**
+     * Our objects should be immutable, by allowing the user to change its state
+     * when ever a setter method is called is a bad practice, since we don't know
+     * which settings the user need, we protect our properties by don't allowing the user
+     * call the method twice, this way we can be sure that our objects are immutable.
+     *
+     * @return void
+     * @test
+     * @expectedException \SendGrid\Mail\Setting\Exception\SpamCheckSettingIsAlreadySetException
+     */
+    public function itShouldFailIfUserTriesToAddSpamCheckSettingTwice()
+    {
+        $settings = new MailSettings;
+        $settings->addSpamCheck(
+            new SpamCheck(true, 1, 'https://spamcatcher.sendgrid.com')
+        );
+        $settings->addSpamCheck(
+            new SpamCheck(false, 2, 'https://other-spam-checker.sendgrid.com')
+        );
+    }
+
+    /**
+     * @param $json
+     * @return string
+     */
+    private function getEncoded($json)
+    {
+        return json_encode(
+            json_decode($json)
+        );
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedBccJson()
+    {
+        return <<<JSON
+        {
+           "bcc":{
+              "enable":true,
+              "email":"test@example.com"
+           }
+        }
+JSON;
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedByPassListManagementJson()
+    {
+        return <<<JSON
+        {
+           "bcc":{
+              "enable":true,
+              "email":"test@example.com"
+           },
+           "bypass_list_management":{
+              "enable":true
+           }
+        }
+JSON;
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedFooterJson()
+    {
+        return <<<JSON
+        {
+           "bcc":{
+              "enable":true,
+              "email":"test@example.com"
+           },
+           "bypass_list_management":{
+              "enable":true
+           },
+           "footer":{
+              "enable":true,
+              "text":"Footer Text",
+              "html":"<html><body>Footer Text</body></html>"
+           }
+        }
+JSON;
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedSandBoxModeJson()
+    {
+        return <<<JSON
+        {
+           "bcc":{
+              "enable":true,
+              "email":"test@example.com"
+           },
+           "bypass_list_management":{
+              "enable":true
+           },
+           "footer":{
+              "enable":true,
+              "text":"Footer Text",
+              "html":"<html><body>Footer Text</body></html>"
+           },
+           "sandbox_mode":{
+              "enable":true
+           }
+        }
+JSON;
+    }
+
+    /**
+     * @return string
+     */
+    public function getExpectedSpamCheckJson()
+    {
+        return <<<JSON
+        {
+           "bcc":{
+              "enable":true,
+              "email":"test@example.com"
+           },
+           "bypass_list_management":{
+              "enable":true
+           },
+           "footer":{
+              "enable":true,
+              "text":"Footer Text",
+              "html":"<html><body>Footer Text</body></html>"
+           },
+           "sandbox_mode":{
+              "enable":true
+           },
+           "spam_check":{
+              "enable":true,
+              "threshold":1,
+              "post_to_url":"https://spamcatcher.sendgrid.com"
+           }
+        }
+JSON;
+    }
+}

--- a/tests/Mail/Setting/TrackingSettingsTest.php
+++ b/tests/Mail/Setting/TrackingSettingsTest.php
@@ -1,0 +1,247 @@
+<?php
+
+namespace Test\Mail\Setting;
+
+use SendGrid\Mail\Setting\OpenTracking;
+use SendGrid\Mail\Setting\ClickTracking;
+use SendGrid\Mail\Setting\GoogleAnalytics;
+use SendGrid\Mail\Setting\TrackingSettings;
+use SendGrid\Mail\Setting\SubscriptionTracking;
+
+final class TrackingSettingsTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @return void
+     * @test
+     */
+    public function itShouldSerializeSuccessfully()
+    {
+        $settings = new TrackingSettings;
+        $this->assertTrue($settings->isEmpty());
+        $this->assertSame('null', json_encode($settings));
+
+        $settings->addClickTracking(new ClickTracking(true, true));
+        $this->assertSame(
+            json_encode($settings),
+            $this->getEncoded($this->getExpectedClickTrackingJson())
+        );
+
+        $settings->addOpenTracking(
+            new OpenTracking(true, 'Optional tag to replace with the open image in the body of the message')
+        );
+        $this->assertSame(
+            json_encode($settings),
+            $this->getEncoded($this->getExpectedOpenTrackingJson())
+        );
+
+        $settings->addSubscriptionTracking(
+            new SubscriptionTracking(
+                true,
+                'text to insert into the text/plain portion of the message',
+                '<html><body>html to insert into the text/html portion of the message</body></html>',
+                'Optional tag to replace with the open image in the body of the message'
+            )
+        );
+        $this->assertSame(
+            json_encode($settings),
+            $this->getEncoded($this->getExpectedSubscriptionTrackingJson())
+        );
+
+        $settings->addGoogleAnalytics(
+            new GoogleAnalytics(true, 'some source', 'some medium', 'some term', 'some content', 'some name')
+        );
+        $this->assertSame(
+            json_encode($settings),
+            $this->getEncoded($this->getExpectedGoogleAnalyticJson())
+        );
+    }
+
+    /**
+     * Our objects should be immutable, by allowing the user to change its state
+     * when ever a setter method is called is a bad practice, since we don't know
+     * which settings the user need, we protect our properties by don't allowing the user
+     * call the method twice, this way we can be sure that our objects are immutable.
+     *
+     * @return void
+     * @test
+     * @expectedException \SendGrid\Mail\Setting\Exception\ClickTrackingIsAlreadySetException
+     */
+    public function itShouldFailIfUserTriesToAddClickTrackingSettingTwice()
+    {
+        $settings = new TrackingSettings;
+        $settings->addClickTracking(new ClickTracking(true, true));
+        $settings->addClickTracking(new ClickTracking(false, false));
+    }
+
+    /**
+     * Our objects should be immutable, by allowing the user to change its state
+     * when ever a setter method is called is a bad practice, since we don't know
+     * which settings the user need, we protect our properties by don't allowing the user
+     * call the method twice, this way we can be sure that our objects are immutable.
+     *
+     * @return void
+     * @test
+     * @expectedException \SendGrid\Mail\Setting\Exception\OpenTrackingSettingIsAlreadySetException
+     */
+    public function itShouldFailIfUserTriesToAddOpenTrackingSettingTwice()
+    {
+        $settings = new TrackingSettings;
+        $settings->addOpenTracking(new OpenTracking(true, 'Text'));
+        $settings->addOpenTracking(new OpenTracking(false, 'I should probably not try to break immutability!'));
+    }
+
+    /**
+     * Our objects should be immutable, by allowing the user to change its state
+     * when ever a setter method is called is a bad practice, since we don't know
+     * which settings the user need, we protect our properties by don't allowing the user
+     * call the method twice, this way we can be sure that our objects are immutable.
+     *
+     * @return void
+     * @test
+     * @expectedException \SendGrid\Mail\Setting\Exception\SubscriptionTrackingSettingIsAlreadySetException
+     */
+    public function itShouldFailIfUserTriesToAddSubscriptionTrackingSettingTwice()
+    {
+        $settings = new TrackingSettings;
+        $settings->addSubscriptionTracking(
+            new SubscriptionTracking(
+                true,
+                'text to insert into the text/plain portion of the message',
+                '<html><body>html to insert into the text/html portion of the message</body></html>',
+                'Optional tag to replace with the open image in the body of the message'
+            )
+        );
+        $settings->addSubscriptionTracking(
+            new SubscriptionTracking(
+                false,
+                'text to insert into the text/plain portion of the message',
+                '<html><body>html to insert into the text/html portion of the message</body></html>',
+                'Optional tag to replace with the open image in the body of the message'
+            )
+        );
+    }
+
+    /**
+     * Our objects should be immutable, by allowing the user to change its state
+     * when ever a setter method is called is a bad practice, since we don't know
+     * which settings the user need, we protect our properties by don't allowing the user
+     * call the method twice, this way we can be sure that our objects are immutable.
+     *
+     * @return void
+     * @test
+     * @expectedException \SendGrid\Mail\Setting\Exception\GoogleAnalyticsSettingIsAlreadySetException
+     */
+    public function itShouldFailIfUserTriesToAddGoogleAnalyticsSettingTwice()
+    {
+        $settings = new TrackingSettings;
+        $settings->addGoogleAnalytics(
+            new GoogleAnalytics(true, 'some source', 'some medium', 'some term', 'some content', 'some name')
+        );
+        $settings->addGoogleAnalytics(
+            new GoogleAnalytics(true, 'source', 'medium', 'term', 'content', 'name')
+        );
+    }
+
+    /**
+     * @param $json
+     * @return string
+     */
+    private function getEncoded($json)
+    {
+        return json_encode(
+            json_decode($json)
+        );
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedClickTrackingJson()
+    {
+        return <<<JSON
+        {
+           "click_tracking":{
+              "enable":true,
+              "enable_text":true
+           }
+        }
+JSON;
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedOpenTrackingJson()
+    {
+        return <<<JSON
+        {
+           "click_tracking":{
+              "enable":true,
+              "enable_text":true
+           },
+           "open_tracking":{
+              "enable":true,
+              "substitution_tag":"Optional tag to replace with the open image in the body of the message"
+           }
+        }
+JSON;
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedSubscriptionTrackingJson()
+    {
+        return <<<JSON
+        {
+           "click_tracking":{
+              "enable":true,
+              "enable_text":true
+           },
+           "open_tracking":{
+              "enable":true,
+              "substitution_tag":"Optional tag to replace with the open image in the body of the message"
+           },
+           "subscription_tracking":{
+              "enable":true,
+              "text":"text to insert into the text/plain portion of the message",
+              "html":"<html><body>html to insert into the text/html portion of the message</body></html>",
+              "substitution_tag":"Optional tag to replace with the open image in the body of the message"
+           }
+        }
+JSON;
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedGoogleAnalyticJson()
+    {
+        return <<<JSOn
+        {
+           "click_tracking":{
+              "enable":true,
+              "enable_text":true
+           },
+           "open_tracking":{
+              "enable":true,
+              "substitution_tag":"Optional tag to replace with the open image in the body of the message"
+           },
+           "subscription_tracking":{
+              "enable":true,
+              "text":"text to insert into the text/plain portion of the message",
+              "html":"<html><body>html to insert into the text/html portion of the message</body></html>",
+              "substitution_tag":"Optional tag to replace with the open image in the body of the message"
+           },
+           "ganalytics":{
+              "enable":true,
+              "utm_source":"some source",
+              "utm_medium":"some medium",
+              "utm_term":"some term",
+              "utm_content":"some content",
+              "utm_campaign":"some content"
+           }
+        }
+JSOn;
+    }
+}

--- a/tests/Personalization/PersonalizationTest.php
+++ b/tests/Personalization/PersonalizationTest.php
@@ -1,0 +1,512 @@
+<?php
+
+namespace Test\Personalization;
+
+use SendGrid\Mail\Essential\To;
+use SendGrid\Mail\Optional\Header;
+use SendGrid\Mail\Optional\Subject;
+use SendGrid\Mail\Essential\Collection\ToCollection;
+use SendGrid\Mail\Optional\Cc;
+use SendGrid\Mail\Optional\Bcc;
+use SendGrid\Mail\Optional\Substitution;
+use SendGrid\Mail\Optional\Collection\HeaderCollection;
+use SendGrid\Mail\Optional\CustomArgument;
+use SendGrid\Mail\Optional\Personalization;
+use SendGrid\Mail\Optional\Collection\CcCollection;
+use SendGrid\Mail\Optional\Collection\BccCollection;
+use SendGrid\Mail\Optional\Collection\SubstitutionCollection;
+use SendGrid\Mail\Optional\Collection\CustomArgumentCollection;
+use SendGrid\Mail\Optional\Collection\PersonalizationCollection;
+
+final class PersonalizationTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @return void
+     * @test
+     */
+    public function itShouldSerializeSuccessfully()
+    {
+        $tos = new ToCollection([
+            new To('to@example.com', 'toPerson'),
+            new To('to@other.com', 'toOtherPerson')
+        ]);
+        $ccs = new CcCollection([
+            new Cc('cc@example.com', 'ccPerson'),
+            new Cc('cc@other.com', 'ccOtherPerson')
+        ]);
+        $bccs = new BccCollection([
+            new Bcc('bcc@example.com', 'bccPerson'),
+            new Bcc('bcc@other.com', 'bccOtherPerson')
+        ]);
+        $headers = new HeaderCollection([
+            new Header('X-Test', 'test'),
+            new Header('X-Mock', 'mock')
+        ]);
+        $substitutions = new SubstitutionCollection([
+            new Substitution('%name%', 'Example User'),
+            new Substitution('%city%', 'Denver')
+        ]);
+        $customArguments = new CustomArgumentCollection([
+            new CustomArgument('user_id', '343'),
+            new CustomArgument('343', 'marketing')
+        ]);
+        $subject = new Subject('SendGrid subject');
+
+        $personalization = new Personalization($tos, $subject, $ccs, $bccs, $headers, $substitutions, $customArguments);
+
+        $this->assertSame(
+            json_encode($personalization),
+            $this->getExpectedDecodedFrom($personalization->getSendAt())
+        );
+    }
+
+    /**
+     * @return void
+     * @test
+     * @expectedException \SendGrid\Mail\Essential\Exception\ToCollectionIsEmptyException
+     */
+    public function itShouldFailIfEmptyToCollectionIsAdded()
+    {
+        $this->createBasePersonalization()
+             ->addTos(new ToCollection);
+    }
+
+    /**
+     * @return void
+     * @test
+     * @expectedException \SendGrid\Mail\Optional\Exception\CcCollectionIsEmptyException
+     */
+    public function itShouldFailIfEmptyCcCollectionIsAdded()
+    {
+        $this->createBasePersonalization()
+             ->addCcs(new CcCollection);
+    }
+
+    /**
+     * @return void
+     * @test
+     * @expectedException \SendGrid\Mail\Optional\Exception\BccCollectionIsEmptyException
+     */
+    public function itShouldFailIfEmptyBccCollectionIsAdded()
+    {
+        $this->createBasePersonalization()
+             ->addBccs(new BccCollection);
+    }
+
+    /**
+     * @return void
+     * @test
+     * @expectedException \SendGrid\Mail\Optional\Exception\SubstitutionCollectionIsEmptyException
+     */
+    public function itShouldFailIfEmptySubstitutionCollectionIsAdded()
+    {
+        $this->createBasePersonalization()
+             ->addSubstitutions(new SubstitutionCollection);
+    }
+
+    /**
+     * @return void
+     * @test
+     * @expectedException \SendGrid\Mail\Optional\Exception\CustomArgumentCollectionIsEmptyException
+     */
+    public function itShouldFailIfEmptyCustomArgumentCollectionIsAdded()
+    {
+        $this->createBasePersonalization()
+             ->addCustomArguments(new CustomArgumentCollection);
+    }
+
+    /**
+     * @return Personalization
+     */
+    private function createBasePersonalization()
+    {
+        return new Personalization(
+            new ToCollection([
+                new To('to@example.com', 'toPerson'),
+                new To('to@other.com', 'toOtherPerson')
+            ])
+        );
+    }
+
+    /**
+     * @return void
+     * @test
+     */
+    public function itShouldAddPersonalizationSuccessfully()
+    {
+        $tos = new ToCollection([
+            new To('to@example.com', 'toPerson'),
+            new To('to@other.com', 'toOtherPerson')
+        ]);
+        $ccs = new CcCollection([
+            new Cc('cc@example.com', 'ccPerson'),
+            new Cc('cc@other.com', 'ccOtherPerson')
+        ]);
+        $bccs = new BccCollection([
+            new Bcc('bcc@example.com', 'bccPerson'),
+            new Bcc('bcc@other.com', 'bccOtherPerson')
+        ]);
+        $headers = new HeaderCollection([
+            new Header('X-Test', 'test'),
+            new Header('X-Mock', 'mock')
+        ]);
+        $substitutions = new SubstitutionCollection([
+            new Substitution('%name%', 'Example User'),
+            new Substitution('%city%', 'Denver')
+        ]);
+        $customArguments = new CustomArgumentCollection([
+            new CustomArgument('user_id', '343'),
+            new CustomArgument('343', 'marketing')
+        ]);
+        $subject = new Subject('SendGrid subject');
+
+        $personalizations = new PersonalizationCollection([
+            new Personalization($tos, $subject, $ccs, $bccs, $headers, $substitutions, $customArguments)
+        ]);
+        $this->assertSame(1, $personalizations->count());
+
+        $personalizations->add(new Personalization($tos));
+        $this->assertSame(2, $personalizations->count());
+
+        $personalizations->addMany([
+            new Personalization($tos, $subject, $ccs, $bccs),
+            new Personalization($tos, $subject, $ccs)
+        ]);
+        $this->assertSame(4, $personalizations->count());
+    }
+
+    /**
+     * @return void
+     * @test
+     */
+    public function itShouldSerializeSuccessfullyFromCollection()
+    {
+        $tos = new ToCollection([
+            new To('to@example.com', 'toPerson'),
+            new To('to@other.com', 'toOtherPerson')
+        ]);
+        $ccs = new CcCollection([
+            new Cc('cc@example.com', 'ccPerson'),
+            new Cc('cc@other.com', 'ccOtherPerson')
+        ]);
+        $bccs = new BccCollection([
+            new Bcc('bcc@example.com', 'bccPerson'),
+            new Bcc('bcc@other.com', 'bccOtherPerson')
+        ]);
+        $headers = new HeaderCollection([
+            new Header('X-Test', 'test'),
+            new Header('X-Mock', 'mock')
+        ]);
+        $substitutions = new SubstitutionCollection([
+            new Substitution('%name%', 'Example User'),
+            new Substitution('%city%', 'Denver')
+        ]);
+        $customArguments = new CustomArgumentCollection([
+            new CustomArgument('user_id', '343'),
+            new CustomArgument('343', 'marketing')
+        ]);
+        $subject = new Subject('SendGrid subject');
+
+        $personalizations = new PersonalizationCollection([
+            new Personalization($tos, $subject),
+            new Personalization($tos, $subject, $ccs),
+            new Personalization($tos, $subject, $ccs, $bccs),
+            new Personalization($tos, $subject, $ccs, $bccs, $headers),
+            new Personalization($tos, $subject, $ccs, $bccs, $headers, $substitutions),
+            new Personalization($tos, $subject, $ccs, $bccs, $headers, $substitutions, $customArguments),
+        ]);
+
+        $this->assertSame(
+            json_encode($personalizations),
+            $this->getExpectedDecodedFromCollection()
+        );
+    }
+
+    /**
+     * @param int $sendAt
+     * @return string
+     */
+    private function getExpectedDecodedFrom($sendAt)
+    {
+        return json_encode(
+            json_decode($this->getExpectedJsonFrom($sendAt))
+        );
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedDecodedFromCollection()
+    {
+        return json_encode(
+            json_decode($this->getExpectedJsonFromCollection())
+        );
+    }
+
+    /**
+     * @param int $sendAt
+     * @return string
+     */
+    private function getExpectedJsonFrom($sendAt)
+    {
+        return <<<JSON
+        {
+           "to":[
+              {
+                 "name":"toPerson",
+                 "email":"to@example.com"
+              },
+              {
+                 "name":"toOtherPerson",
+                 "email":"to@other.com"
+              }
+           ],
+           "cc":[
+              {
+                 "name":"ccPerson",
+                 "email":"cc@example.com"
+              },
+              {
+                 "name":"ccOtherPerson",
+                 "email":"cc@other.com"
+              }
+           ],
+           "bcc":[
+              {
+                 "name":"bccPerson",
+                 "email":"bcc@example.com"
+              },
+              {
+                 "name":"bccOtherPerson",
+                 "email":"bcc@other.com"
+              }
+           ],
+           "subject":"SendGrid subject",
+           "headers":{
+              "X-Test":"test",
+              "X-Mock":"mock"
+           },
+           "substitutions":{
+              "%name%":"Example User",
+              "%city%":"Denver"
+           },
+           "custom_args":{
+              "user_id":"343",
+              "343":"marketing"
+           },
+           "send_at":{$sendAt}
+        }
+JSON;
+    }
+
+    /**
+     * @return string
+     */
+    public function getExpectedJsonFromCollection()
+    {
+        $sendAt = strtotime((new \DateTime)->format('Y-m-d H:i:s'));
+
+        return <<<JSON
+        [
+           {
+              "to":[
+                 {
+                    "name":"toPerson",
+                    "email":"to@example.com"
+                 },
+                 {
+                    "name":"toOtherPerson",
+                    "email":"to@other.com"
+                 }
+              ],
+              "subject":"SendGrid subject",
+              "send_at":{$sendAt}
+           },
+           {
+              "to":[
+                 {
+                    "name":"toPerson",
+                    "email":"to@example.com"
+                 },
+                 {
+                    "name":"toOtherPerson",
+                    "email":"to@other.com"
+                 }
+              ],
+              "cc":[
+                 {
+                    "name":"ccPerson",
+                    "email":"cc@example.com"
+                 },
+                 {
+                    "name":"ccOtherPerson",
+                    "email":"cc@other.com"
+                 }
+              ],
+              "subject":"SendGrid subject",
+              "send_at":{$sendAt}
+           },
+           {
+              "to":[
+                 {
+                    "name":"toPerson",
+                    "email":"to@example.com"
+                 },
+                 {
+                    "name":"toOtherPerson",
+                    "email":"to@other.com"
+                 }
+              ],
+              "cc":[
+                 {
+                    "name":"ccPerson",
+                    "email":"cc@example.com"
+                 },
+                 {
+                    "name":"ccOtherPerson",
+                    "email":"cc@other.com"
+                 }
+              ],
+              "bcc":[
+                 {
+                    "name":"bccPerson",
+                    "email":"bcc@example.com"
+                 },
+                 {
+                    "name":"bccOtherPerson",
+                    "email":"bcc@other.com"
+                 }
+              ],
+              "subject":"SendGrid subject",
+              "send_at":{$sendAt}
+           },
+           {
+              "to":[
+                 {
+                    "name":"toPerson",
+                    "email":"to@example.com"
+                 },
+                 {
+                    "name":"toOtherPerson",
+                    "email":"to@other.com"
+                 }
+              ],
+              "cc":[
+                 {
+                    "name":"ccPerson",
+                    "email":"cc@example.com"
+                 },
+                 {
+                    "name":"ccOtherPerson",
+                    "email":"cc@other.com"
+                 }
+              ],
+              "bcc":[
+                 {
+                    "name":"bccPerson",
+                    "email":"bcc@example.com"
+                 },
+                 {
+                    "name":"bccOtherPerson",
+                    "email":"bcc@other.com"
+                 }
+              ],
+              "subject":"SendGrid subject",
+              "headers":{
+                 "X-Test":"test",
+                 "X-Mock":"mock"
+              },
+              "send_at":{$sendAt}
+           },
+           {
+              "to":[
+                 {
+                    "name":"toPerson",
+                    "email":"to@example.com"
+                 },
+                 {
+                    "name":"toOtherPerson",
+                    "email":"to@other.com"
+                 }
+              ],
+              "cc":[
+                 {
+                    "name":"ccPerson",
+                    "email":"cc@example.com"
+                 },
+                 {
+                    "name":"ccOtherPerson",
+                    "email":"cc@other.com"
+                 }
+              ],
+              "bcc":[
+                 {
+                    "name":"bccPerson",
+                    "email":"bcc@example.com"
+                 },
+                 {
+                    "name":"bccOtherPerson",
+                    "email":"bcc@other.com"
+                 }
+              ],
+              "subject":"SendGrid subject",
+              "headers":{
+                 "X-Test":"test",
+                 "X-Mock":"mock"
+              },
+              "substitutions":{
+                 "%name%":"Example User",
+                 "%city%":"Denver"
+              },
+              "send_at":{$sendAt}
+           },
+           {
+              "to":[
+                 {
+                    "name":"toPerson",
+                    "email":"to@example.com"
+                 },
+                 {
+                    "name":"toOtherPerson",
+                    "email":"to@other.com"
+                 }
+              ],
+              "cc":[
+                 {
+                    "name":"ccPerson",
+                    "email":"cc@example.com"
+                 },
+                 {
+                    "name":"ccOtherPerson",
+                    "email":"cc@other.com"
+                 }
+              ],
+              "bcc":[
+                 {
+                    "name":"bccPerson",
+                    "email":"bcc@example.com"
+                 },
+                 {
+                    "name":"bccOtherPerson",
+                    "email":"bcc@other.com"
+                 }
+              ],
+              "subject":"SendGrid subject",
+              "headers":{
+                 "X-Test":"test",
+                 "X-Mock":"mock"
+              },
+              "substitutions":{
+                 "%name%":"Example User",
+                 "%city%":"Denver"
+              },
+              "custom_args":{
+                 "user_id":"343",
+                 "343":"marketing"
+              },
+              "send_at":{$sendAt}
+           }
+        ]
+JSON;
+    }
+}

--- a/tests/Section/SectionTest.php
+++ b/tests/Section/SectionTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Test\Section;
+
+use SendGrid\Mail\Optional\Collection\SectionCollection;
+use SendGrid\Mail\Optional\Section;
+
+final class SectionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @param string $key
+     * @param string $value
+     * @return void
+     * @test
+     * @dataProvider keyValueProvider
+     */
+    public function itShouldSerializeSuccessfully($key, $value)
+    {
+        $this->assertSame(
+            json_encode(new Section($key, $value)),
+            $this->getExpectedDecodedFrom($key, $value)
+        );
+    }
+
+    /**
+     * @return void
+     * @test
+     */
+    public function itShouldSerializeSuccessfullyFromCollection()
+    {
+        $contents = new SectionCollection([
+            new Section('key', 'value'),
+            new Section('otherKey', 'otherValue'),
+            new Section('thirdKey', 'thirdValue')
+        ]);
+        $this->assertSame(
+            json_encode($contents),
+            $this->getExpectedDecodedFromCollection()
+        );
+    }
+
+    /**
+     * @return void
+     * @test
+     */
+    public function itShouldAddAttachmentSuccessfully()
+    {
+        $customArguments = new SectionCollection([
+            new Section('key', 'value'),
+        ]);
+        $this->assertSame(1, $customArguments->count());
+
+        $customArguments->add(new Section('otherKey', 'otherValue'));
+        $this->assertSame(2, $customArguments->count());
+
+        $customArguments->addMany([
+            new Section('keyFromMany', 'valueFromMany'),
+            new Section('aKey', 'aValue')
+        ]);
+        $this->assertSame(4, $customArguments->count());
+    }
+
+    /**
+     * @return void
+     * @test
+     * @expectedException \InvalidArgumentException
+     */
+    public function itShouldValidateScalar()
+    {
+        new Section(1, false);
+    }
+
+    /**
+     * @return array
+     */
+    public function keyValueProvider()
+    {
+        return [
+            [
+                '%section1%',
+                'Substitution Text for Section 1'
+            ],
+            [
+                '%section2%',
+                'Substitution Text for Section 2'
+            ]
+        ];
+    }
+
+    /**
+     * @param string $key
+     * @param string $value
+     * @return string
+     */
+    private function getExpectedDecodedFrom($key, $value)
+    {
+        return json_encode(
+            json_decode($this->getExpectedJsonFrom($key, $value))
+        );
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedDecodedFromCollection()
+    {
+        return json_encode(
+            json_decode($this->getExpectedJsonFromCollection())
+        );
+    }
+
+    /**
+     * @param string $key
+     * @param string $value
+     * @return string
+     */
+    public function getExpectedJsonFrom($key, $value)
+    {
+        return <<<JSON
+        {
+           "{$key}" : "{$value}"
+        }
+JSON;
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedJsonFromCollection()
+    {
+        return <<<JSON
+        {
+           "key"      : "value",
+           "otherKey" : "otherValue",
+           "thirdKey" : "thirdValue"
+        }
+JSON;
+    }
+}


### PR DESCRIPTION
Since the company I work for wants to use `SendGrid` and the library seems to be a bit hard to understand and violates some OOP and clean code principles, I came up with the proposal of this PR:

- Moved the whole library to the folder `src` which IMHO makes more sense since we already know that this is a library, no need to be under `lib` namespace, it's redundant.
- Using `PSR4` for autoloading, that's pretty much a standard nowadays.
- Full compatibility with `PSR2` coding standard.
- Move the tests to `tests` folder, and now it should be more simpler to test, e.g: `vendor/bin/phpunit` for all tests or if you want to filter an specific one `vendor/bin/phpunit --filter Mail` or any other class.
- The code now it's much more robust using `type hinting`, this is a feature since `PHP 5.1` this library has a base compatibility for `PHP 5.6`
- Adding doc blocks, these are useful for scalar types since we can't type hint `scalar types` which are compatible since `PHP 7.0`
- When json_encode `Mail Class`, it returns the same output as with the old `Mail Class`, it shouldn't affect anything
- Make sure our `Mail` object is always in a valid state through immutability and the use of value objects with their correspondent validations
- Currently `OK (59 tests, 105 assertions)` covered by tests.
- Added a custom `Collection` class which helps to manipulate `one` or `many` objects, encapsulating reusable logic to handle `arrays`
- Adds `Reply to` to be a `collection` instead of one `entity`

Examples:

Mail with essential options:

```php
$from = new From('sendgrid@sendgrid.com', 'SendGrid PHP');
$subject = new Subject('Hello World from the SendGrid PHP Library');
$tos = new ToCollection([
    new To("test@example.com", "Test User"),
    new To('other@example.com', "Other Test User")
]);
$content = new ContentCollection([
    new Content('text/plain', 'some text here'),
    new Content('text/html', '<html><body>some text here</body></html>')
]);

$mail = new Mail($from, $tos, $content, $subject);
```

As seen in the example above, now `Mail` accepts collections of `To` which can be `one or many` and also for Content.

Now `Mail` accepts, as said before, the option to add `one` or `many` depending on the option the user may need, if a user needs to add for example, multiple Cc e-mails, he/she can do it as follow:

```php
$mail->addCcs(new CcCollection([
    new Cc("test@example.com", "Test User"),
    new Cc('other@example.com', "Other Test User")
]));
```
or if they need only one:

```php
$mail->addCc(new Cc("test@example.com", "Test User"));
```
Same applies for other optional options the user may want to add, `bcc`, `header`, etc.

The code now protects immutability on classes such as `mail settings` or `tracking settings`, since these classes have properties that are optional, once a user add one of them, the library won't accept to re-set the property, e.g:

```php
 * @test
 * @expectedException \SendGrid\Mail\Setting\Exception\ByPassListManagementSettingIsAlreadySetException
 */
public function itShouldFailIfUserTriesToAddByPassListManagementSettingTwice()
{
    $settings = new MailSettings;
    $settings->addByPassListManagement(
        new ByPassListManagement(true)
    );
    /** I'm trying to break immutability but it won't work :-( */
    $settings->addByPassListManagement(
        new ByPassListManagement(false)
    );
}
```
This helps to make the library much more predictable, easy to maintain, debug, test and extend!, same applies for other classes that have optional properties.

This PR also refactors `SendGrid` class, it should be more easier to implement, e.g:

```php
$sendgrid = new SendGrid('API_KEY', ['options']);
/** Using the same Mail Object from the beginning of this explanation */
/** This returns a response as well and can perform as before */
$response = $sendgrid->send($mail)
echo $response->statusCode();
print_r($response->headers());
echo $response->body();
```

Also is not needed only to use a `Mail` object, can be done through Json as well

```php
$sendgrid = new SendGrid('API_KEY', ['options']);
$requestBody = json_encode('some-object');
$response = $sendgrid->sendFromJson($requestBody)
echo $response->statusCode();
print_r($response->headers());
echo $response->body();
```

If `Client` is needed for whatever reason, we can use get it calling `getClient()` method from `SendGrid` class, it used to be `public` which breaks OOP encapsulation at its max, e.g:

Before:

```php
$sendgrid = new SendGrid('API_KEY', ['options']);
/** Wrong because I can do this*/
$sendgrid->client = '¯\_(ツ)_/¯ ';
$client = $sendgrid->client;
```
Now:

```php
$sendgrid = new SendGrid('API_KEY', ['options']);
$client = $sendgrid->getClient();
```

That's pretty much it, I may have forgotten something, but don't hesitate to ask !.

Thanks.

@thinkingserious Please, review it when you have time.