### PR TITLE
Add TROUBLESHOOTING.md section about fixing error 415

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -12,6 +12,7 @@ If you can't find a solution below, please open an [issue](https://github.com/se
 * [Versions](#versions)
 * [Environment Variables and Your SendGrid API Key](#environment)
 * [Using the Package Manager](#package-manager)
+* [Fixing Error 415](#error-415)
 
 <a name="migrating"></a>
 ## Migrating from v2 to v3
@@ -87,3 +88,14 @@ In most cases we recommend you download the latest version of the library, but i
   }
 }
 ```
+
+<a name="error-415"></a>
+## Fixing Error 415
+
+If you're getting the following error while using this library:
+
+`Content-Type should be application/json.`
+
+It is most likely due to a linebreak in your API key. Passing your key through `trim` should fix this:
+
+`$apiKey = trim($apiKey)`


### PR DESCRIPTION
Wasn't sure how to phrase it while keeping it simple.

[Explanation of issue and fix](https://github.com/sendgrid/sendgrid-php/issues/371#issuecomment-335913858)

> If you were to have a file like this:
> 
> `.sendgrid`: (notice the linebreak)
> ```
> SG.**
> 
> ```
> and you used it like
> ```php
> $apiKey = file_get_contents('.sendgrid');
> $sendgrid = new \SendGrid($apiKey);
> $sendgrid->client->mail()->send()->post($message);
> ```
> 
> The raw HTTP request, sent by curl, would look like: (notice the linebreak)
> ```
> POST /v3/mail/send
> Host: api.sendgrid.com
> Authorization: Bearer SG.**
> 
> User-Agent: sendgrid/*;php
> Accept: application/json
> Content-Type: application/json
> ```
> 
> This causes all the headers after the `Authorization` header to be treated as the message body and effectively ignored. A simple pass through `trim` will fix this: `$apiKey = trim($apiKey);`

(would be simple to shove a trim in `lib/SendGrid.php` as well, assuming valid api keys have no excess whitespace)