### PR TITLE
Adding Google App engine installation with composer instructions

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -14,6 +14,7 @@ If you can't find a solution below, please open an [issue](https://github.com/se
 * [Using the Package Manager](#package-manager)
 * [Fixing Error 415](#error-415)
 * [Viewing the Request Body](#request-body)
+* [Google App Engine installation](#GAE-instructions)
 
 <a name="migrating"></a>
 ## Migrating from v2 to v3
@@ -111,3 +112,8 @@ You can do this right before you call `$response = $sg->client->mail()->send()->
 ```php
 echo json_encode($mail, JSON_PRETTY_PRINT);
 ```
+
+<a name="GAE-instructions"></a>
+## Google App Engine installation
+
+Please refer to [`USE_CASES.md`](https://github.com/sendgrid/sendgrid-php/blob/master/USE_CASES.md#GAE-instructions) for additional instructions.

--- a/USE_CASES.md
+++ b/USE_CASES.md
@@ -5,6 +5,7 @@ This documentation provides examples for specific use cases. Please [open an iss
 * [Transactional Templates](#transactional-templates)
 * [How to Setup a Domain Whitelabel](#domain-whitelabel)
 * [How to View Email Statistics](#email-stats)
+* [Additional instructions for Google App Engine installation](#GAE-instructions)
 
 <a name="attachments"></a>
 # Attachments
@@ -182,3 +183,14 @@ Find more information about all of SendGrid's whitelabeling related documentatio
 You can find documentation for how to view your email statistics via the UI [here](https://app.sendgrid.com/statistics) and via API [here](https://github.com/sendgrid/sendgrid-php/blob/master/USAGE.md#stats).
 
 Alternatively, we can post events to a URL of your choice via our [Event Webhook](https://sendgrid.com/docs/API_Reference/Webhooks/event.html) about events that occur as SendGrid processes your email.
+
+<a name="GAE-instructions"></a>
+# Additional instructions for Google App Engine installation
+
+Google App Engine installations with composer require creation of file `php.ini` in the base folder(the same directory as the `app.yaml` file). You can read more about this file [here](https://cloud.google.com/appengine/docs/standard/php/config/php_ini).
+
+The file `php.ini` should contain:
+
+```ini
+google_app_engine.enable_curl_lite = 1
+```


### PR DESCRIPTION
Adds `php.ini` file instructions to both files `USE_CASES.md` and `TROUBLESHOOTING.md`

Fixes #423

@thinkingserious please review.