### PR TITLE
Omit PHP closing tag in use case sample

### DIFF
--- a/USE_CASES.md
+++ b/USE_CASES.md
@@ -42,8 +42,6 @@ $response = $sg->client->mail()->send()->post($mail);
 echo $response->statusCode();
 print_r($response->headers());
 echo $response->body();
-
-?>
 ```
 
 <a name="transactional-templates"></a>


### PR DESCRIPTION
Per http://php.net/manual/en/language.basic-syntax.phptags.php it's best to
omit PHP closing tags when a code file is pure PHP to avoid to accidentally
send whitelines to the buffer output, before headers could be sent.

As such, documentation should not use closing tags to reflect best practices.