### PR TITLE
Don't close <img> tag in HTML

### DIFF
--- a/examples/mail/mail.php
+++ b/examples/mail/mail.php
@@ -57,7 +57,7 @@ $request_body = json_decode('{
   "content": [
     {
       "type": "text/html", 
-      "value": "<html><p>Hello, world!</p><img src=[CID GOES HERE]></img></html>"
+      "value": "<html><p>Hello, world!</p><img src=[CID GOES HERE] /></html>"
     }
   ], 
   "custom_args": {

--- a/test/unit/SendGridTest.php
+++ b/test/unit/SendGridTest.php
@@ -1096,7 +1096,7 @@ class SendGridTest_SendGrid extends \PHPUnit_Framework_TestCase
   "content": [
     {
       "type": "text/html",
-      "value": "<html><p>Hello, world!</p><img src=[CID GOES HERE]></img></html>"
+      "value": "<html><p>Hello, world!</p><img src=[CID GOES HERE] /></html>"
     }
   ],
   "custom_args": {


### PR DESCRIPTION
Reference: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img

"Tag omission: Must have a start tag and must not have an end tag."