### PR TITLE
Add license date range unit test

### DIFF
--- a/test/unit/SendGridTest.php
+++ b/test/unit/SendGridTest.php
@@ -1052,6 +1052,12 @@ class SendGridTest_SendGrid extends \PHPUnit_Framework_TestCase
         $this->assertEquals($response->statusCode(), 200);
     }
 
+    public function test_license_date_range()
+    {
+    	$license_file = file_get_contents("../../LICENSE.txt");
+    	$this-> assertInternalType("int", strpos($license_file, date("Y")));
+    }
+
     public function test_mail_batch_post()
     {
         $request_headers = array("X-Mock: 201");

--- a/test/unit/SendGridTest.php
+++ b/test/unit/SendGridTest.php
@@ -1055,7 +1055,8 @@ class SendGridTest_SendGrid extends \PHPUnit_Framework_TestCase
     public function test_license_date_range()
     {
     	$license_file = file_get_contents("../../LICENSE.txt");
-    	$this->assertInternalType("int", strpos($license_file, date("Y")));
+        $current_year = date("Y");
+    	$this->assertInternalType("int", strpos($license_file, "Copyright (c) 2012-" . $current_year . " SendGrid, Inc."));
     }
 
     public function test_mail_batch_post()

--- a/test/unit/SendGridTest.php
+++ b/test/unit/SendGridTest.php
@@ -1055,7 +1055,7 @@ class SendGridTest_SendGrid extends \PHPUnit_Framework_TestCase
     public function test_license_date_range()
     {
     	$license_file = file_get_contents("../../LICENSE.txt");
-    	$this-> assertInternalType("int", strpos($license_file, date("Y")));
+    	$this->assertInternalType("int", strpos($license_file, date("Y")));
     }
 
     public function test_mail_batch_post()


### PR DESCRIPTION
Fixes #532 .
Simple unit test to verify if the license file contains the end year as the current one