### PR TITLE
Add ability to impersonate subuser

### DIFF
--- a/lib/SendGrid.php
+++ b/lib/SendGrid.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * This library allows you to quickly and easily send emails through 
+ * This library allows you to quickly and easily send emails through
  * SendGrid using PHP.
- * 
+ *
  * PHP Version - 5.6, 7.0, 7.1, 7.2
  *
  * @package   SendGrid\Tests
@@ -10,12 +10,12 @@
  * @copyright 2018 SendGrid
  * @license   https://opensource.org/licenses/MIT The MIT License
  * @version   GIT: <git_id>
- * @link      http://packagist.org/packages/sendgrid/sendgrid 
+ * @link      http://packagist.org/packages/sendgrid/sendgrid
  */
 
 /**
  * This class is the interface to the SendGrid Web API
- * 
+ *
  * @package SendGrid\Mail
  */
 class SendGrid
@@ -34,8 +34,8 @@ class SendGrid
      * Setup the HTTP Client
      *
      * @param string $apiKey  Your SendGrid API Key.
-     * @param array  $options An array of options, currently only "host" and 
-     *                        "curl" are implemented.
+     * @param array  $options An array of options, currently only "host", "curl" and
+     *                        "impersonateSubuser" are implemented.
      */
     public function __construct($apiKey, $options = array())
     {
@@ -45,8 +45,12 @@ class SendGrid
             'Accept: application/json'
             );
 
-        $host = isset($options['host']) ? $options['host'] : 
+        $host = isset($options['host']) ? $options['host'] :
             'https://api.sendgrid.com';
+
+        if (!empty($options['impersonateSubuser'])) {
+            $headers[] = 'On-Behalf-Of: '. $options['impersonateSubuser'];
+        }
 
         $curlOptions = isset($options['curl']) ? $options['curl'] : null;
 
@@ -63,7 +67,7 @@ class SendGrid
      * Make an API request
      *
      * @param \SendGrid\Mail\Mail $email A Mail object, containing the request object
-     * 
+     *
      * @return \SendGrid\Response
      */
     public function send(\SendGrid\Mail\Mail $email)

--- a/test/unit/SendGridTest.php
+++ b/test/unit/SendGridTest.php
@@ -73,5 +73,16 @@ class SendGridTest extends BaseTestClass
             $sg4->client->getCurlOptions(),
             [10004 => '127.0.0.1:8000']
         );
+
+        $subuser = 'abcxyz@this.is.a.test.subuser';
+        $headers[] = 'On-Behalf-Of: ' . $subuser;
+        $sg5 = new \SendGrid(
+            self::$apiKey,
+            ['impersonateSubuser' => $subuser]
+        );
+        $this->assertSame(
+            $headers,
+            $sg5->client->getHeaders()
+        );
     }
 }


### PR DESCRIPTION
Sendgrid API has a feature allowing parent accounts to impersonate
subusers by including an HTTP header "On-Behalf-Of" in each API request.
This commit enables setting the value for impersonation when creating
the Sendgrid API Client instance, through the `$options` argument.

Fixes #551
