### PR TITLE
Bad Request

### DIFF
--- a/lib/helpers/mail/Mail.php
+++ b/lib/helpers/mail/Mail.php
@@ -842,7 +842,7 @@ class Personalization implements \JsonSerializable
 
     public function addSubstitution($key, $value)
     {
-        $this->substitutions[$key] = $value;
+        $this->substitutions[$key] = (string)$value;
     }
 
     public function getSubstitutions()


### PR DESCRIPTION
API level addressing of the string-only in addSubstitution arg rule.   Every long integer triggers a bad request.

<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.


Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Fixes # 

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added in line documentation to the code I modified

### Short description of what this PR does:
- 
- 

If you have questions, please send an email to [Sendgrid](mailto:dx@sendgrid.com), or file a Github Issue in this repository.
