### PR TITLE
[WIP] Add assertion to ensure `post()` returns an instance of `Response`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_script:
 - cd test/unit
 
 script:
-- "../../vendor/bin/phpunit . --filter test* --coverage-clover=coverage.xml"
+- "../../vendor/bin/phpunit . --filter MailSendTest --coverage-clover=coverage.xml" # temporarily changed just to avoid other errors, just want to perform this test by now
 
 after_script:
 - cd ../..

--- a/test/unit/Mail/MailSendTest.php
+++ b/test/unit/Mail/MailSendTest.php
@@ -148,6 +148,7 @@ class MailSendTest extends BaseTestClass
 }');
         $request_headers = ["X-Mock: 202"];
         $response = self::$sg->client->mail()->send()->post($request_body, null, $request_headers);
-        $this->assertEquals(202, $response->statusCode());
+        $this->assertSame(202, $response->statusCode());
+        $this->assertInstanceOf('SendGrid\\Response', $response);
     }
 }


### PR DESCRIPTION
|Q            |A     |
|---          |---   |
|Branch       |master|
|Bug fix?     |no    |
|New feature? |no    |
|BC breaks?   |no    |
|Deprecations?|no    |
|Tests pass?  |no    |
|Fixed tickets|n/a   |
|License      |MIT   |
|Doc PR       |n/a   |

Please, don't merge yet. I'm trying to reproduce an issue which I have with my implementation, where `$client->mail()->send()->post($mail);` is returning an instance of `Client` instead of `Response`.