### PR TITLE
Attachments now automatically get base64 encoded if they are not already

### DIFF
--- a/lib/mail/Attachment.php
+++ b/lib/mail/Attachment.php
@@ -77,7 +77,7 @@ class Attachment implements \JsonSerializable
      */
     public function setContent($content)
     {
-        if(base64_decode($content, true) == "") {
+        if(!base64_decode($content, true)) {
             $this->content = base64_encode($content);
         } else {
             $this->content = $content;

--- a/lib/mail/Attachment.php
+++ b/lib/mail/Attachment.php
@@ -77,7 +77,7 @@ class Attachment implements \JsonSerializable
      */
     public function setContent($content)
     {
-        if(!base64_decode($content, true)) {
+        if(!$this->isBase64($content)) {
             $this->content = base64_encode($content);
         } else {
             $this->content = $content;
@@ -182,6 +182,15 @@ class Attachment implements \JsonSerializable
     public function getContentID()
     {
         return $this->content_id;
+    }
+
+    private function isBase64($string) {
+        $decoded_data = base64_decode($string, true);
+        $encoded_data = base64_encode($decoded_data);
+        if ($encoded_data != $string) return false;
+        else if (!ctype_print($decoded_data)) return false;
+
+        return true;
     }
 
     /**

--- a/lib/mail/Attachment.php
+++ b/lib/mail/Attachment.php
@@ -1,7 +1,7 @@
-<?php 
+<?php
 /**
  * This helper builds the Attachment object for a /mail/send API call
- * 
+ *
  * PHP Version - 5.6, 7.0, 7.1, 7.2
  *
  * @package   SendGrid\Mail
@@ -9,13 +9,13 @@
  * @copyright 2018 SendGrid
  * @license   https://opensource.org/licenses/MIT The MIT License
  * @version   GIT: <git_id>
- * @link      http://packagist.org/packages/sendgrid/sendgrid 
+ * @link      http://packagist.org/packages/sendgrid/sendgrid
  */
 namespace SendGrid\Mail;
 
 /**
  * This class is used to construct a Attachment object for the /mail/send API call
- * 
+ *
  * @package SendGrid\Mail
  */
 class Attachment implements \JsonSerializable
@@ -32,16 +32,16 @@ class Attachment implements \JsonSerializable
     // @var string Used when disposition is inline to diplay the file within the
     // body of the email
     private $content_id;
- 
+
     /**
      * Optional constructor
      *
      * @param string $content     Base64 encoded content
      * @param string $type        Mime type of the attachment
      * @param string $filename    File name of the attachment
-     * @param string $disposition How the attachment should be displayed: inline 
+     * @param string $disposition How the attachment should be displayed: inline
      *                            or attachment, default is attachment
-     * @param string $content_id  Used when disposition is inline to diplay the 
+     * @param string $content_id  Used when disposition is inline to diplay the
      *                            file within the body of the email
      */
     public function __construct(
@@ -72,19 +72,23 @@ class Attachment implements \JsonSerializable
      * Add the content to a Attachment object
      *
      * @param string $content Base64 encoded content
-     * 
+     *
      * @return null
-     */  
+     */
     public function setContent($content)
     {
-        $this->content = $content;
+        if(base64_decode($content) === "") {
+            $this->content = base64_encode($content);
+        } else {
+            $this->content = $content;
+        }
     }
 
     /**
      * Retrieve the content from a Attachment object
-     * 
+     *
      * @return string
-     */  
+     */
     public function getContent()
     {
         return $this->content;
@@ -94,9 +98,9 @@ class Attachment implements \JsonSerializable
      * Add the mime type to a Attachment object
      *
      * @param string $type Mime type of the attachment
-     * 
+     *
      * @return null
-     */  
+     */
     public function setType($type)
     {
         $this->type = $type;
@@ -104,9 +108,9 @@ class Attachment implements \JsonSerializable
 
     /**
      * Retrieve the mime type from a Attachment object
-     * 
+     *
      * @return string
-     */  
+     */
     public function getType()
     {
         return $this->type;
@@ -116,9 +120,9 @@ class Attachment implements \JsonSerializable
      * Add the file name to a Attachment object
      *
      * @param string $filename File name of the attachment
-     * 
+     *
      * @return null
-     */  
+     */
     public function setFilename($filename)
     {
         $this->filename = $filename;
@@ -126,9 +130,9 @@ class Attachment implements \JsonSerializable
 
     /**
      * Retrieve the file name from a Attachment object
-     * 
+     *
      * @return string
-     */  
+     */
     public function getFilename()
     {
         return $this->filename;
@@ -137,11 +141,11 @@ class Attachment implements \JsonSerializable
     /**
      * Add the disposition to a Attachment object
      *
-     * @param string $disposition How the attachment should be displayed: 
+     * @param string $disposition How the attachment should be displayed:
      *                            inline or attachment, default is attachment
-     * 
+     *
      * @return null
-     */  
+     */
     public function setDisposition($disposition)
     {
         $this->disposition = $disposition;
@@ -149,9 +153,9 @@ class Attachment implements \JsonSerializable
 
     /**
      * Retrieve the disposition from a Attachment object
-     * 
+     *
      * @return string
-     */  
+     */
     public function getDisposition()
     {
         return $this->disposition;
@@ -160,11 +164,11 @@ class Attachment implements \JsonSerializable
     /**
      * Add the content id to a Attachment object
      *
-     * @param string $content_id Used when disposition is inline to diplay 
+     * @param string $content_id Used when disposition is inline to diplay
      *                           the file within the body of the email
-     * 
+     *
      * @return null
-     */  
+     */
     public function setContentID($content_id)
     {
         $this->content_id = $content_id;
@@ -172,9 +176,9 @@ class Attachment implements \JsonSerializable
 
     /**
      * Retrieve the content id from a Attachment object
-     * 
+     *
      * @return string
-     */  
+     */
     public function getContentID()
     {
         return $this->content_id;
@@ -182,9 +186,9 @@ class Attachment implements \JsonSerializable
 
     /**
      * Return an array representing a Attachment object for the SendGrid API
-     * 
+     *
      * @return null|array
-     */  
+     */
     public function jsonSerialize()
     {
         return array_filter(

--- a/lib/mail/Attachment.php
+++ b/lib/mail/Attachment.php
@@ -184,6 +184,12 @@ class Attachment implements \JsonSerializable
         return $this->content_id;
     }
 
+    /**
+     *  Verifies whether or not the provided string is a valid base64 string
+     *
+     * @param $string string The string that has to be checked
+     * @return bool
+     */
     private function isBase64($string) {
         $decoded_data = base64_decode($string, true);
         $encoded_data = base64_encode($decoded_data);

--- a/lib/mail/Attachment.php
+++ b/lib/mail/Attachment.php
@@ -77,7 +77,7 @@ class Attachment implements \JsonSerializable
      */
     public function setContent($content)
     {
-        if(base64_decode($content) === "") {
+        if(base64_decode($content, true) == "") {
             $this->content = base64_encode($content);
         } else {
             $this->content = $content;

--- a/test/unit/Attachments.php
+++ b/test/unit/Attachments.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * This file tests attachments.
+ *
+ * PHP Version - 5.6, 7.0, 7.1, 7.2
+ *
+ * @package   SendGrid\Tests
+ * @author    Elmer Thomas <dx@sendgrid.com>
+ * @copyright 2018 SendGrid
+ * @license   https://opensource.org/licenses/MIT The MIT License
+ * @version   GIT: <git_id>
+ * @link      http://packagist.org/packages/sendgrid/sendgrid
+ */
+namespace SendGrid\Tests;
+
+use PHPUnit\Framework\TestCase;
+use SendGrid\Mail\Attachment;
+
+/**
+ * This file tests attachments.
+ *
+ * @package SendGrid\Tests
+ */
+class AttachmentsTests extends TestCase
+{
+    public function testWillEncodeNonBase64String() {
+
+        $attachment = new Attachment();
+        $testString = 'Sendgrid is awesome!';
+
+        $attachment->setContent($testString);
+
+        $this->assertEquals(base64_encode($testString), $attachment->getContent());
+    }
+
+    public function testWillNotEncodeBase64String() {
+
+        $attachment = new Attachment();
+        $testString = base64_encode('Sendgrid is awesome!');
+
+        $attachment->setContent($testString);
+
+        $this->assertEquals($testString, $attachment->getContent());
+    }
+}

--- a/test/unit/KitchenSinkTest.php
+++ b/test/unit/KitchenSinkTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file tests the request object generation for a /mail/send API call
- * 
+ *
  * PHP Version - 5.6, 7.0, 7.1, 7.2
  *
  * @package   SendGrid\Tests
@@ -9,7 +9,7 @@
  * @copyright 2018 SendGrid
  * @license   https://opensource.org/licenses/MIT The MIT License
  * @version   GIT: <git_id>
- * @link      http://packagist.org/packages/sendgrid/sendgrid 
+ * @link      http://packagist.org/packages/sendgrid/sendgrid
  */
 namespace SendGrid\Tests;
 
@@ -17,7 +17,7 @@ use SendGrid\Tests\BaseTestClass;
 
 /**
  * This class tests the request object generation for a /mail/send API call
- * 
+ *
  * @package SendGrid\Tests
  */
 class KitchenSinkTest extends BaseTestClass
@@ -38,21 +38,21 @@ class KitchenSinkTest extends BaseTestClass
   },
   "attachments": [
     {
-      "content": "base64 encoded content1",
+      "content": "YmFzZTY0IGVuY29kZWQgY29udGVudDE=",
       "content_id": "Banner",
       "disposition": "inline",
       "filename": "banner.png",
       "type": "image/png"
     },
     {
-      "content": "base64 encoded content2",
+      "content": "YmFzZTY0IGVuY29kZWQgY29udGVudDI=",
       "content_id": "Banner 3",
       "disposition": "attachment",
       "filename": "image/jpeg",
       "type": "banner2.jpeg"
     },
     {
-      "content": "base64 encoded content3",
+      "content": "YmFzZTY0IGVuY29kZWQgY29udGVudDM=",
       "content_id": "Banner 3",
       "disposition": "inline",
       "filename": "image/gif",
@@ -225,18 +225,18 @@ JSON;
 
     /**
      * Test all parameters without using objects
-     * 
+     *
      * @return null
-     */ 
+     */
     public function testKitchenSinkExampleWithoutObjects()
     {
         $email = new \SendGrid\Mail\Mail();
 
-        // For a detailed description of each of these settings, 
-        // please see the 
+        // For a detailed description of each of these settings,
+        // please see the
         // [documentation](https://sendgrid.com/docs/API_Reference/api_v3.html).
         $email->setSubject("Sending with SendGrid is Fun 2");
-    
+
         $email->addTo("test@example.com", "Example User");
         $email->addTo("test+1@example.com", "Example User1");
         $toEmails = [
@@ -244,21 +244,21 @@ JSON;
             "test+3@example.com" => "Example User3"
         ];
         $email->addTos($toEmails);
-    
+
         $email->addCc("test+4@example.com", "Example User4");
         $ccEmails = [
             "test+5@example.com" => "Example User5",
             "test+6@example.com" => "Example User6"
         ];
         $email->addCcs($ccEmails);
-    
+
         $email->addBcc("test+7@example.com", "Example User7");
         $bccEmails = [
             "test+8@example.com" => "Example User8",
             "test+9@example.com" => "Example User9"
         ];
         $email->addBccs($bccEmails);
-   
+
         $email->addHeader("X-Test1", "Test1");
         $email->addHeader("X-Test2", "Test2");
         $headers = [
@@ -266,7 +266,7 @@ JSON;
             "X-Test4" => "Test4",
         ];
         $email->addHeaders($headers);
-     
+
         $email->addSubstitution("%name1%", "Example Name 1");
         $email->addSubstitution("%city1%", "Denver");
         $substitutions = [
@@ -315,7 +315,7 @@ JSON;
             "Banner"
         );
         $attachments = [
-            [   
+            [
                 "base64 encoded content2",
                 "banner2.jpeg",
                 "image/jpeg",
@@ -373,7 +373,7 @@ JSON;
         $email->enableSandBoxMode();
         //$email->disableSandBoxMode();
         $email->setSpamCheck(true, 1, "http://mydomain.com");
-        
+
         // Tracking Settings
         $email->setClickTracking(true, true);
         $email->setOpenTracking(true, "--sub--");
@@ -399,15 +399,15 @@ JSON;
 
     /**
      * Test all parameters using objects
-     * 
+     *
      * @return null
-     */ 
+     */
     public function testKitchenSinkExampleWithObjects()
     {
         $email = new \SendGrid\Mail\Mail();
 
-        // For a detailed description of each of these settings, 
-        // please see the 
+        // For a detailed description of each of these settings,
+        // please see the
         // [documentation](https://sendgrid.com/docs/API_Reference/api_v3.html).
         $email->setSubject(
             new \SendGrid\Mail\Subject("Sending with SendGrid is Fun 2")
@@ -415,23 +415,23 @@ JSON;
 
         $email->addTo(new \SendGrid\Mail\To("test@example.com", "Example User"));
         $email->addTo(new \SendGrid\Mail\To("test+1@example.com", "Example User1"));
-        $toEmails = [ 
+        $toEmails = [
             new \SendGrid\Mail\To("test+2@example.com", "Example User2"),
             new \SendGrid\Mail\To("test+3@example.com", "Example User3")
         ];
         $email->addTos($toEmails);
 
         $email->addCc(new \SendGrid\Mail\Cc("test+4@example.com", "Example User4"));
-        $ccEmails = [ 
+        $ccEmails = [
             new \SendGrid\Mail\Cc("test+5@example.com", "Example User5"),
             new \SendGrid\Mail\Cc("test+6@example.com", "Example User6")
         ];
         $email->addCcs($ccEmails);
- 
+
         $email->addBcc(
             new \SendGrid\Mail\Bcc("test+7@example.com", "Example User7")
         );
-        $bccEmails = [ 
+        $bccEmails = [
             new \SendGrid\Mail\Bcc("test+8@example.com", "Example User8"),
             new \SendGrid\Mail\Bcc("test+9@example.com", "Example User9")
         ];


### PR DESCRIPTION
# Fixes # 
Fixes #611 

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added in line documentation to the code I modified

### Short description of what this PR does:
- When an attachement is added it first checks whether or not it has already been base64 encoded, if not it encodes its.
