### PR TITLE
Fix setGroupsToDisplay's handling of array arguments

### DIFF
--- a/lib/mail/GroupsToDisplay.php
+++ b/lib/mail/GroupsToDisplay.php
@@ -55,7 +55,11 @@ class GroupsToDisplay implements \JsonSerializable
      */ 
     public function setGroupsToDisplay($groups_to_display)
     {
-        $this->groups_to_display[] = $groups_to_display;
+        if (is_array($groups_to_display)) {
+            $this->groups_to_display = $groups_to_display;
+        } else {
+            $this->groups_to_display[] = $groups_to_display;
+        }
     }
 
     /**

--- a/test/unit/KitchenSinkTest.php
+++ b/test/unit/KitchenSinkTest.php
@@ -28,12 +28,10 @@ class KitchenSinkTest extends BaseTestClass
   "asm": {
     "group_id": 1,
     "groups_to_display": [
-      [
-        1,
-        2,
-        3,
-        4
-      ]
+      1,
+      2,
+      3,
+      4
     ]
   },
   "attachments": [


### PR DESCRIPTION
# Fixes #624 

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.

### Short description of what this PR does:
Fixes #624: Fix setGroupsToDisplay's handling of array arguments
