### PR TITLE
Documentation and a file fix for non-composer use

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,9 @@ The following is the minimum needed code to send an email. You may find more exa
 <?php
 require 'vendor/autoload.php'; // If you're using Composer (recommended)
 // Comment out the above line if not using Composer
-// require("./sendgrid-php.php"); 
-// If not using Composer, uncomment the above line
+// require({path-to-php-http-client-master/loader.php});    // see https://github.com/sendgrid/php-http-client/blob/master/README.md#install-without-composer
+// require("./lib/loader.php");
+// If not using Composer, uncomment the above two lines
 
 $email = new \SendGrid\Mail\Mail(); 
 $email->setFrom("test@example.com", "Example User");
@@ -121,8 +122,9 @@ The `SendGrid\Mail` constructor creates a [personalization object](https://sendg
 <?php
 require 'vendor/autoload.php'; // If you're using Composer (recommended)
 // Comment out the above line if not using Composer
-// require("./sendgrid-php.php"); 
-// If not using Composer, uncomment the above line
+// require({path-to-php-http-client-master/loader.php});    // see https://github.com/sendgrid/php-http-client/blob/master/README.md#install-without-composer
+// require("./lib/loader.php");
+// If not using Composer, uncomment the above two lines
 
 $apiKey = getenv('SENDGRID_API_KEY');
 $sg = new \SendGrid($apiKey);
@@ -143,8 +145,9 @@ try {
 <?php
 require 'vendor/autoload.php'; // If you're using Composer (recommended)
 // Comment out the above line if not using Composer
-// require("./sendgrid-php.php"); 
-// If not using Composer, uncomment the above line
+// require({path-to-php-http-client-master/loader.php});    // see https://github.com/sendgrid/php-http-client/blob/master/README.md#install-without-composer
+// require("./lib/loader.php");
+// If not using Composer, uncomment the above two lines
 
 $apiKey = getenv('SENDGRID_API_KEY');
 $sg = new \SendGrid($apiKey);

--- a/USAGE.md
+++ b/USAGE.md
@@ -5,8 +5,9 @@ This documentation is based on our [OAI specification](https://github.com/sendgr
 ```php
 require 'vendor/autoload.php'; // If you're using Composer (recommended)
 // Comment out the above line if not using Composer
-// require("./sendgrid-php.php"); 
-// If not using Composer, uncomment the above line
+// require("./lib/loader.php");
+// require({path-to-php-http-client-master/loader.php});    // see https://github.com/sendgrid/php-http-client/blob/master/README.md#install-without-composer
+// If not using Composer, uncomment the above two lines
 
 $apiKey = getenv('SENDGRID_API_KEY');
 $sg = new \SendGrid($apiKey);

--- a/USE_CASES.md
+++ b/USE_CASES.md
@@ -21,8 +21,9 @@ Here is an example of attaching a text file to your email, assuming that text fi
 <?php
 require 'vendor/autoload.php'; // If you're using Composer (recommended)
 // comment out the above line if not using Composer
-// require("./sendgrid-php.php"); 
-// If not using Composer, uncomment the above line
+// require({path-to-php-http-client-master/loader.php});    // see https://github.com/sendgrid/php-http-client/blob/master/README.md#install-without-composer
+// require("./lib/loader.php");
+// If not using Composer, uncomment the above two lines
 
 $email = new \SendGrid\Mail\Mail(); 
 $email->setFrom("test@example.com", "Example User");
@@ -59,8 +60,9 @@ try {
 <?php
 require 'vendor/autoload.php'; // If you're using Composer (recommended)
 // comment out the above line if not using Composer
-// require("./sendgrid-php.php"); 
-// If not using Composer, uncomment the above line
+// require({path-to-php-http-client-master/loader.php});    // see https://github.com/sendgrid/php-http-client/blob/master/README.md#install-without-composer
+// require("./lib/loader.php");
+// If not using Composer, uncomment the above two lines
 
 $email = new \SendGrid\Mail\Mail();
 
@@ -245,8 +247,9 @@ OR
 <?php
 require 'vendor/autoload.php'; // If you're using Composer (recommended)
 // comment out the above line if not using Composer
-// require("./sendgrid-php.php"); 
-// If not using Composer, uncomment the above line
+// require({path-to-php-http-client-master/loader.php});    // see https://github.com/sendgrid/php-http-client/blob/master/README.md#install-without-composer
+// require("./lib/loader.php");
+// If not using Composer, uncomment the above two lines
 
 $email = new \SendGrid\Mail\Mail();
 
@@ -485,8 +488,9 @@ try {
 <?php
 require 'vendor/autoload.php'; // If you're using Composer (recommended)
 // comment out the above line if not using Composer
-// require("./sendgrid-php.php"); 
-// If not using Composer, uncomment the above line
+// require({path-to-php-http-client-master/loader.php});    // see https://github.com/sendgrid/php-http-client/blob/master/README.md#install-without-composer
+// require("./lib/loader.php");
+// If not using Composer, uncomment the above two lines
 
 $email = new \SendGrid\Mail\Mail(); 
 $email->setFrom("test@example.com", "Example User");
@@ -513,8 +517,10 @@ OR
 <?php
 require 'vendor/autoload.php'; // If you're using Composer (recommended)
 // comment out the above line if not using Composer
-// require("./sendgrid-php.php"); 
-// If not using Composer, uncomment the above line
+// require({path-to-php-http-client-master/loader.php});    // see https://github.com/sendgrid/php-http-client/blob/master/README.md#install-without-composer
+// require("./lib/loader.php");
+// If not using Composer, uncomment the above two lines
+
 $from = new \SendGrid\Mail\From("test@example.com", "Example User");
 $subject = new \SendGrid\Mail\Subject("Sending with SendGrid is Fun");
 $to = new \SendGrid\Mail\To("test@example.com", "Example User");
@@ -549,8 +555,10 @@ try {
 <?php
 require 'vendor/autoload.php'; // If you're using Composer (recommended)
 // comment out the above line if not using Composer
-// require("./sendgrid-php.php"); 
-// If not using Composer, uncomment the above line
+// require({path-to-php-http-client-master/loader.php});    // see https://github.com/sendgrid/php-http-client/blob/master/README.md#install-without-composer
+// require("./lib/loader.php");
+// If not using Composer, uncomment the above two lines
+
 $email = new \SendGrid\Mail\Mail(); 
 $email->setFrom("test@example.com", "Example User");
 $tos = [ 
@@ -581,8 +589,9 @@ OR
 <?php
 require 'vendor/autoload.php'; // If you're using Composer (recommended)
 // comment out the above line if not using Composer
-// require("./sendgrid-php.php"); 
-// If not using Composer, uncomment the above line
+// require({path-to-php-http-client-master/loader.php});    // see https://github.com/sendgrid/php-http-client/blob/master/README.md#install-without-composer
+// require("./lib/loader.php");
+// If not using Composer, uncomment the above two lines
 
 $from = new \SendGrid\Mail\From("test@example.com", "Example User");
 $tos = [ 
@@ -623,8 +632,10 @@ try {
 <?php
 require 'vendor/autoload.php'; // If you're using Composer (recommended)
 // comment out the above line if not using Composer
-// require("./sendgrid-php.php"); 
-// If not using Composer, uncomment the above line
+// require({path-to-php-http-client-master/loader.php});    // see https://github.com/sendgrid/php-http-client/blob/master/README.md#install-without-composer
+// require("./lib/loader.php");
+// If not using Composer, uncomment the above two lines
+
 $from = new \SendGrid\Mail\From("test@example.com", "Example User");
 $tos = [ 
     new \SendGrid\Mail\To(
@@ -690,8 +701,10 @@ OR
 <?php
 require 'vendor/autoload.php'; // If you're using Composer (recommended)
 // comment out the above line if not using Composer
-// require("./sendgrid-php.php"); 
-// If not using Composer, uncomment the above line
+// require({path-to-php-http-client-master/loader.php});    // see https://github.com/sendgrid/php-http-client/blob/master/README.md#install-without-composer
+// require("./lib/loader.php");
+// If not using Composer, uncomment the above two lines
+
 $from = new \SendGrid\Mail\From("test@example.com", "Example User");
 $tos = [ 
     new \SendGrid\Mail\To(
@@ -795,8 +808,9 @@ I hope you are having a great day in -city- :)
 <?php
 require 'vendor/autoload.php'; // If you're using Composer (recommended)
 // comment out the above line if not using Composer
-// require("./sendgrid-php.php"); 
-// If not using Composer, uncomment the above line
+// require({path-to-php-http-client-master/loader.php});    // see https://github.com/sendgrid/php-http-client/blob/master/README.md#install-without-composer
+// require("./lib/loader.php");
+// If not using Composer, uncomment the above two lines
 
 use \SendGrid\Mail\From as From;
 use \SendGrid\Mail\To as To;

--- a/lib/loader.php
+++ b/lib/loader.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Allows us to include one file instead of two when working without composer.
- * 
+ *
  * PHP Version - 5.6, 7.0, 7.1, 7.2
  *
  * @package   SendGrid\Tests
@@ -9,14 +9,15 @@
  * @copyright 2018 SendGrid
  * @license   https://opensource.org/licenses/MIT The MIT License
  * @version   GIT: <git_id>
- * @link      http://packagist.org/packages/sendgrid/sendgrid 
+ * @link      http://packagist.org/packages/sendgrid/sendgrid
  */
 require_once __DIR__ . '/SendGrid.php';
 require_once __DIR__ . '/contacts/Recipient.php';
 require_once __DIR__ . '/contacts/RecipientForm.php';
+require_once __DIR__ . '/mail/EmailAddress.php';
 require_once __DIR__ . '/mail/Asm.php';
 require_once __DIR__ . '/mail/Attachment.php';
-require_once __DIR__ . '/mail/BatchId';
+require_once __DIR__ . '/mail/BatchId.php';
 require_once __DIR__ . '/mail/Bcc.php';
 require_once __DIR__ . '/mail/BccSettings.php';
 require_once __DIR__ . '/mail/BypassListManagement.php';
@@ -25,7 +26,6 @@ require_once __DIR__ . '/mail/Cc.php';
 require_once __DIR__ . '/mail/ClickTracking.php';
 require_once __DIR__ . '/mail/Content.php';
 require_once __DIR__ . '/mail/CustomArg.php';
-require_once __DIR__ . '/mail/EmailAddress.php';
 require_once __DIR__ . '/mail/Footer.php';
 require_once __DIR__ . '/mail/From.php';
 require_once __DIR__ . '/mail/Ganalytics.php';


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.


Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Fixes # 

### Checklist
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [x] I have added necessary documentation about the functionality in the appropriate .md file

### Short description of what this PR does:
The following changes relate to use in a non-composer environment:
* Add missing file extension for `/mail/BatchId` in `loader.php`
* Re-order requires to ensure `EmailAddress` is loaded before `Bcc` (`Bcc` depends on `EmailAddress` being loaded)
* Change `README.md` to reference `./lib/loader.php` instead of `./sendgrid-php.php` for non-composer use.
* Change example documentation to reference the required HTTP library dependency and how to install it without composer

NOTE: It is likely that the `use` commands in https://github.com/sendgrid/sendgrid-php/blob/master/USE_CASES.md#transactional-templates can be removed as well.
