### PR TITLE
feat: Allows for a user to utilize self-signed certificates

### DIFF
--- a/lib/BaseSendGridClientInterface.php
+++ b/lib/BaseSendGridClientInterface.php
@@ -26,7 +26,8 @@ abstract class BaseSendGridClientInterface
      * @param string $auth Authorization header value.
      * @param string $host Default host/base URL for the client.
      * @param array $options An array of options, currently only "host", "curl",
-     *                       "version", and "impersonateSubuser", are implemented.
+     *                       "version", "verify_ssl", and "impersonateSubuser",
+     *                       are implemented.
      */
     public function __construct($auth, $host, $options = array())
     {

--- a/lib/BaseSendGridClientInterface.php
+++ b/lib/BaseSendGridClientInterface.php
@@ -44,15 +44,10 @@ abstract class BaseSendGridClientInterface
             $headers[] = 'On-Behalf-Of: ' . $options['impersonateSubuser'];
         }
 
-        $curlOptions = isset($options['curl']) ? $options['curl'] : null;
+        $this->client = new Client($host, $headers, $version);
 
-        $this->client = new Client(
-            $host,
-            $headers,
-            $version,
-            null,
-            $curlOptions
-        );
+        $this->client->setCurlOptions(isset($options['curl']) ? $options['curl'] : null);
+        $this->client->setVerifySSLCerts(isset($options['verify_ssl']) ? $options['verify_ssl'] : true);
     }
 
     /**

--- a/lib/BaseSendGridClientInterface.php
+++ b/lib/BaseSendGridClientInterface.php
@@ -47,7 +47,7 @@ abstract class BaseSendGridClientInterface
 
         $this->client = new Client($host, $headers, $version);
 
-        $this->client->setCurlOptions(isset($options['curl']) ? $options['curl'] : null);
+        $this->client->setCurlOptions(isset($options['curl']) ? $options['curl'] : []);
         $this->client->setVerifySSLCerts(isset($options['verify_ssl']) ? $options['verify_ssl'] : true);
     }
 

--- a/lib/SendGrid.php
+++ b/lib/SendGrid.php
@@ -13,7 +13,8 @@ class SendGrid extends BaseSendGridClientInterface
      *
      * @param string $apiKey Your Twilio SendGrid API Key.
      * @param array $options An array of options, currently only "host", "curl",
-     *                       "version", and "impersonateSubuser", are implemented.
+     *                       "version", "verify_ssl", and "impersonateSubuser",
+     *                       are implemented.
      */
     public function __construct($apiKey, $options = array())
     {

--- a/lib/TwilioEmail.php
+++ b/lib/TwilioEmail.php
@@ -14,7 +14,8 @@ class TwilioEmail extends BaseSendGridClientInterface
      * @param string $username Username to authenticate with
      * @param string $password Password to authenticate with
      * @param array $options An array of options, currently only "host", "curl",
-     *                       "version", and "impersonateSubuser", are implemented.
+     *                       "version", "verify_ssl", and "impersonateSubuser",
+     *                       are implemented.
      */
     public function __construct($username, $password, $options = array())
     {


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.


Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# New Feature

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [x] I have added in line documentation to the code I modified

### Short description of what this PR does:
- Allows the ability for a user to utilise self-signed certificates with SendGrid
- Current Client implementation will fail to process a `curl_init()` function if, for example, the user is testing the implementation on a local server with an unknown CA
- See [PR here](https://github.com/sendgrid/php-http-client/pull/101)

If you have questions, please send an email to [Sendgrid](mailto:dx@sendgrid.com), or file a Github Issue in this repository.
