### PR TITLE
docs: remove `sudo` requirement for running docker

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -27,7 +27,7 @@ This Docker image contains:
   - `docker image build --tag="sendgrid/php7" ./docker`
   - `docker run -itd --name="sendgrid_php7" -v $(pwd):/root/sendgrid-php sendgrid/php7 /bin/bash`
 5. Run the tests within the Docker container
-  - `sudo docker exec -it sendgrid_php7 /bin/bash -c 'cd sendgrid-php/test; ../vendor/bin/phpunit . --filter test*; exec "${SHELL:-sh}"'`
+  - `docker exec -it sendgrid_php7 /bin/bash -c 'cd sendgrid-php/test; ../vendor/bin/phpunit . --filter test*; exec "${SHELL:-sh}"'`
 
 Now you can continue development locally, and run `../vendor/bin/phpunit . --filter test*` inside of the container to test. Replace `test*` with the name of a particular test if you do not wish to run the entire suite of tests.
 


### PR DESCRIPTION

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified

### Short description of what this PR does:

We shouldn't need to run Docker as root if it's been installed
correctly, and the user is already part of the `docker` group.

If this was not the case, we would've required other steps to be run
with `sudo`.
