### PR TITLE
Fixes #739 Wrong condition

### DIFF
--- a/lib/mail/EmailAddress.php
+++ b/lib/mail/EmailAddress.php
@@ -70,8 +70,8 @@ class EmailAddress implements \JsonSerializable
      */ 
     public function setEmailAddress($emailAddress)
     {
-        if (!is_string($emailAddress) &&
-            filter_var($emailAddress, FILTER_VALIDATE_EMAIL)
+        if (!(is_string($emailAddress) &&
+            filter_var($emailAddress, FILTER_VALIDATE_EMAIL))
         ) {
             throw new TypeException(
                 '$emailAddress must be valid and of type string.'

--- a/test/unit/MailHelperTest.php
+++ b/test/unit/MailHelperTest.php
@@ -70,4 +70,15 @@ class MailTest_Mail extends \PHPUnit\Framework\TestCase
             '{"name":"\\"O\'Keeffe, John \\\\\\"Billy\\\\\\"\\"","email":"test@example.com"}'
         );
     }
+    
+    /**
+     * This method tests TypeException for wrong email address
+     *
+     * @expectedException \SendGrid\Mail\TypeException
+     */
+    public function testEmailAddress()
+    {
+		$email = new EmailAddress();
+    	$email->setEmailAddress('test@example.com@wrong');
+    }    
 }


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.


Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Fixes #739  

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified

### Short description of what this PR does:

The next condition on line 73 is wrong (file /mail/EmailAddress.php).
if (!is_string($emailAddress) && filter_var($emailAddress, FILTER_VALIDATE_EMAIL))

It turns out that email address shouldn't be a string and should be a valid address simultaneously in order to throw exception.

Probably the right condition is:
if (!(is_string($emailAddress) && filter_var($emailAddress, FILTER_VALIDATE_EMAIL)))
If you have questions, please send an email to [Sendgrid](mailto:dx@sendgrid.com), or file a Github Issue in this repository.