### PR TITLE
WIP: Add script for generating GitHub release notes

### DIFF
--- a/scripts/add-github-release-notes.php
+++ b/scripts/add-github-release-notes.php
@@ -1,0 +1,92 @@
+#!/usr/bin/php
+<?php
+
+/** @var string */
+const RELEASES_URI = 'https://api.github.com/repos/sendgrid/sendgrid-php/releases';
+/** @var string */
+$githubToken = getenv('GITHUB_TOKEN');
+
+/**
+ * Parse the CHANGELOG to retrieve the latest details.
+ * @return array
+ * @throws Exception
+ */
+function parseLatestComponents()
+{
+    $changelog = file_get_contents(__DIR__.'/../CHANGELOG.md');
+
+    // Parse the latest CHANGELOG contents to 'tag_name', 'name', and 'body'
+    preg_match(
+        '/## \[(?<version>v?[\d.]+?)\] - \(?(\d{4}-\d{2}-\d{2})\)? ##\s(?<body>[\s\S]+?)\s+## \[/m',
+        $changelog,
+        $info
+    );
+
+    if (isset($info['version']) && isset($info['body'])) {
+        return [
+            'tag_name' => $info['version'],
+            'name'     => $info['version'],
+            'body'     => $info['body'],
+        ];
+    }
+
+    throw new Exception('Unable to parse the CHANGELOG for the latest version!');
+}
+
+/**
+ * Send the release creation request to the GitHub API.
+ * @param $data The JSON-encoded array object
+ * @param $githubToken The GitHub API token
+ * @return bool
+ * @throws Exception
+ */
+function sendReleaseNotes($data, $githubToken)
+{
+    $curl = curl_init(RELEASES_URI);
+
+    curl_setopt_array(
+        $curl,
+        [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_POSTFIELDS     => $data,
+            CURLOPT_USERAGENT      => 'SendGrid',
+            CURLOPT_HTTPHEADER     => [
+                'authorization: token '.$githubToken,
+                'content-type: application/json',
+            ],
+        ]
+    );
+
+    curl_exec($curl);
+
+    $responseCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+
+    curl_close($curl);
+
+    if ($responseCode === 201) {
+        return true;
+    }
+
+    throw new Exception('An error occurred while creating the release notes.');
+}
+
+try {
+    if (!$githubToken) {
+        throw new Exception('No GitHub API token has been specified.');
+    }
+
+    echo 'Parsing the CHANGELOG components.'.PHP_EOL;
+    $data = parseLatestComponents();
+
+    echo 'Encoding the release notes'.PHP_EOL;
+    $encoded = json_encode($data);
+
+    echo 'Sending content to the GitHub API:'.PHP_EOL;
+    echo '> '.$encoded.PHP_EOL;
+    sendReleaseNotes($encoded, $githubToken);
+
+    echo 'Successfully added release notes for release: '.$data['tag_name'];
+    echo PHP_EOL;
+} catch (Exception $e) {
+    exit('ERROR: '.$e->getMessage());
+}


### PR DESCRIPTION
Fixes #750 

See sendgrid/smtpapi-php#103 for additional information.

----

I have marked this as WIP due to it requiring an environment variable (`GITHUB_TOKEN`) and I'm not sure if this should be run from Travis CI. I guess alternatively, it could prompt the user for a token if one isn't available in the environment.

----

### Checklist
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified

### Short description of what this PR does:
- Added a script for creating GitHub releases (with notes) from the changes in the [`CHANGELOG.md`](https://github.com/sendgrid/sendgrid-php/blob/master/CHANGELOG.md) file

### Testing

I have tested this on my repository using the `7.2.1` tag ([output release here](https://github.com/pxgamer/sendgrid-php/releases/tag/7.2.1)).

I've changed the regex on this as I noticed versions here do not have the `v` prefix, and dates aren't in parentheses anymore. Not sure if I should change to this regex on the other PR.