### PR TITLE
PHP 7.3 support and fix Prism download problem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 before_script:
 - composer install
 - "./test/prism.sh &"
-- sleep 60
+- sleep 20
 - cd test
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ php:
 - 7.0
 - 7.1
 - 7.2
+- 7.3
 
 notifications:
   hipchat:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 before_script:
 - composer install
 - "./test/prism.sh &"
-- sleep 20
+- sleep 60
 - cd test
 
 script:

--- a/sendgrid-php.php
+++ b/sendgrid-php.php
@@ -1,15 +1,3 @@
 <?php
-/**
- * This file autoloads the vendored dependencies for a /mail/send API call
- * 
- * PHP Version - 5.6, 7.0, 7.1, 7.2
- *
- * @package   SendGrid\Mail
- * @author    Elmer Thomas <dx@sendgrid.com>
- * @copyright 2018 SendGrid
- * @license   https://opensource.org/licenses/MIT The MIT License
- * @version   GIT: <git_id>
- * @link      http://packagist.org/packages/sendgrid/sendgrid 
- */
 require __DIR__ . '/vendor/autoload.php';
 ?>

--- a/test/prism.sh
+++ b/test/prism.sh
@@ -38,13 +38,13 @@ LATEST=$(get_latest_release)
 URL="https://github.com/stoplightio/prism/releases/download/v2.0.17/prism_$PLATFORM"
 DEST=../prism/bin/prism
 
-if [ -z $LATEST ] ; then
-  echo "Error requesting. Download binary from ${URL}"
-  exit 1
-else
-  curl -L $URL -o $DEST
-  chmod +x $DEST
-fi
+# if [ -z $LATEST ] ; then
+#   echo "Error requesting. Download binary from ${URL}"
+#   exit 1
+# else
+curl -L $URL -o $DEST
+chmod +x $DEST
+# fi
 }
 
 run () {

--- a/test/prism.sh
+++ b/test/prism.sh
@@ -34,7 +34,8 @@ fi
 
 mkdir -p ../prism/bin
 LATEST=$(get_latest_release)
-URL="https://github.com/stoplightio/prism/releases/download/$LATEST/prism_$PLATFORM"
+# URL="https://github.com/stoplightio/prism/releases/download/$LATEST/prism_$PLATFORM"
+URL="https://github.com/stoplightio/prism/releases/download/v2.0.17/prism_$PLATFORM"
 DEST=../prism/bin/prism
 
 if [ -z $LATEST ] ; then


### PR DESCRIPTION
- Added support for 7.3 in Travis.yml
- Update the Prism script so that it does not fail when it can't find the latest version number
