### PR TITLE
Fixes #788  - Add missing parameter for addCc and addBcc methods

### DIFF
--- a/lib/mail/Mail.php
+++ b/lib/mail/Mail.php
@@ -393,6 +393,8 @@ class Mail implements \JsonSerializable
      *
      * @param string|Cc $cc Email address or Cc object
      * @param string $name Recipient name
+     * @param Substitution[]|array|null $substitutions Personalized
+     *                                                         substitutions
      * @param int|null $personalizationIndex Index into an array of
      *                                                   existing Personalization
      *                                                   objects
@@ -402,6 +404,7 @@ class Mail implements \JsonSerializable
     public function addCc(
         $cc,
         $name = null,
+        $substitutions = null,
         $personalizationIndex = null,
         $personalization = null
     ) {
@@ -413,6 +416,7 @@ class Mail implements \JsonSerializable
             "Cc",
             $cc,
             $name,
+            $substitutions,
             $personalizationIndex,
             $personalization
         );
@@ -448,6 +452,8 @@ class Mail implements \JsonSerializable
      *
      * @param string|Bcc $bcc Email address or Bcc object
      * @param string $name Recipient name
+     * @param Substitution[]|array|null $substitutions Personalized
+     *                                                         substitutions
      * @param int|null $personalizationIndex Index into an array of
      *                                                   existing Personalization
      *                                                   objects
@@ -457,6 +463,7 @@ class Mail implements \JsonSerializable
     public function addBcc(
         $bcc,
         $name = null,
+        $substitutions = null,
         $personalizationIndex = null,
         $personalization = null
     ) {
@@ -468,6 +475,7 @@ class Mail implements \JsonSerializable
             "Bcc",
             $bcc,
             $name,
+            $substitutions,
             $personalizationIndex,
             $personalization
         );


### PR DESCRIPTION
Fixes #788 

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the development branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified

### Short description of what this PR does:
Fixed missing parameter issue. Allows adding CC/BCC when passing a $personalizationIndex.
Example usage also included in KitchenSink example in another pull request: https://github.com/sendgrid/sendgrid-php/pull/836