### PR TITLE
feat: Add an option to override SendGrid Client path version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,9 +8,12 @@ WORKDIR /root
 
 # install Prism
 ADD https://raw.githubusercontent.com/stoplightio/prism/master/install install.sh
+RUN apt-get update && apt-get install dos2unix
 RUN chmod +x ./install.sh && sync && \
+    dos2unix ./install.sh && \
     ./install.sh && \
     rm ./install.sh
+
 
 # set up default Twilio SendGrid env
 WORKDIR /root
@@ -18,5 +21,6 @@ WORKDIR /root
 RUN mkdir sendgrid-php
 COPY entrypoint.sh entrypoint.sh
 RUN chmod +x entrypoint.sh
+RUN dos2unix ./entrypoint.sh
 ENTRYPOINT ["./entrypoint.sh"]
 CMD ["--mock"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ ENV SENDGRID_API_KEY $SENDGRID_API_KEY
 WORKDIR /root
 
 # install Prism
-ADD https://raw.githubusercontent.com/stoplightio/prism/master/install.sh install.sh
+ADD https://raw.githubusercontent.com/stoplightio/prism/master/install install.sh
 RUN chmod +x ./install.sh && sync && \
     ./install.sh && \
     rm ./install.sh

--- a/lib/SendGrid.php
+++ b/lib/SendGrid.php
@@ -34,7 +34,7 @@ class SendGrid
      * Setup the HTTP Client
      *
      * @param string $apiKey  Your Twilio SendGrid API Key.
-     * @param array  $options An array of options, currently only "host", "curl" and
+     * @param array  $options An array of options, currently only "host", "curl", "path" and
      *                        "impersonateSubuser" are implemented.
      */
     public function __construct($apiKey, $options = array())
@@ -48,6 +48,9 @@ class SendGrid
         $host = isset($options['host']) ? $options['host'] :
             'https://api.sendgrid.com';
 
+        $path = isset($options['path']) ? $options['path'] :
+            '/v3';
+
         if (!empty($options['impersonateSubuser'])) {
             $headers[] = 'On-Behalf-Of: '. $options['impersonateSubuser'];
         }
@@ -57,7 +60,7 @@ class SendGrid
         $this->client = new \SendGrid\Client(
             $host,
             $headers,
-            '/v3',
+            $path,
             null,
             $curlOptions
         );

--- a/test/unit/SendGridTest.php
+++ b/test/unit/SendGridTest.php
@@ -85,4 +85,26 @@ class SendGridTest extends BaseTestClass
             $sg5->client->getHeaders()
         );
     }
+    
+
+    /**
+     * Test that user can override the path when instantiating a new SendGrid client
+     */
+    public function testCanOverridePath()
+    {
+        $opts['path'] = 'v4';
+
+        $sg = new \SendGrid(self::$apiKey, $opts);
+        $headers = [
+            'Authorization: Bearer ' . self::$apiKey,
+            'User-Agent: sendgrid/' . $sg->version . ';php',
+            'Accept: application/json'
+        ];
+
+        $this->assertEquals(
+            $sg->client->getHost(),
+            'https://api.sendgrid.com',
+            '/v4'
+        );
+    }
 }


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.

**All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Fixes # 

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the development branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added in line documentation to the code I modified

### Short description of what this PR does:
- At my job, we have a facade API that sits in between consumers and SendGrid; it does some various things that are important to our business. We overrode the host which worked fine, but it also added /v3 to the end, so that our URLs ended up being _http://company-email-api.domain.com/api/v1/email/v3_. 
- I thought this was a simple update to give users more flexibility and should be fully backwards compatible.
- I also updated a couple pieces of the Dockerfile; The URL for prism bash script was a 404, so I updated to the current existing install script. I also added support for dos2unix, which coverts line endings. My host machine is windows, and I had lots of issues getting the docker container to run for tests because of line endings.
- I didn't apt-get remove dos2linux because I still needed to use it for the unit tests, manually. 
- *I am new to PHP, Docker, PHPUnit, so if I've done something wrong, please let me know*

If you have questions, please send an email to [Twilio Sendgrid](mailto:dx@sendgrid.com), or file a Github Issue in this repository.
