### PR TITLE
fix: resolve deprecation notices when using Composer 1.10(-dev)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
   "type": "library",
   "autoload": {
     "psr-4": {
-      "SendGrid\\": "lib/",
       "SendGrid\\Mail\\": "lib/mail/",
       "SendGrid\\Contacts\\": "lib/contacts/",
       "SendGrid\\Stats\\": "lib/stats/"
@@ -41,7 +40,9 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "SendGrid\\Tests\\": "test/"
-    }
+      "SendGrid\\Tests\\Integration\\": "test/integration",
+      "SendGrid\\Tests\\Unit\\": "test/unit"
+    },
+    "files": ["test/BaseTestClass.php"]
   }
 }

--- a/test/BaseTestClass.php
+++ b/test/BaseTestClass.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * This file contains the base class for testing the request object 
+ * This file contains the base class for testing the request object
  * generation for a /mail/send API call
- * 
+ *
  * PHP Version - 5.6, 7.0, 7.1, 7.2
  *
  * @package   SendGrid\Tests
@@ -10,47 +10,50 @@
  * @copyright 2018-19 Twilio SendGrid
  * @license   https://opensource.org/licenses/MIT The MIT License
  * @version   GIT: <git_id>
- * @link      http://packagist.org/packages/sendgrid/sendgrid 
+ * @link      http://packagist.org/packages/sendgrid/sendgrid
  */
 namespace SendGrid\Tests;
 
 use PHPUnit\Framework\TestCase;
+use SendGrid;
+use Swaggest\JsonDiff\Exception;
 use Swaggest\JsonDiff\JsonDiff;
 use Swaggest\JsonDiff\JsonPatch;
 
 /**
- * This class facilitates testing the request object 
+ * This class facilitates testing the request object
  * generation for a /mail/send API call
- * 
+ *
  * @package SendGrid\Mail
  */
 class BaseTestClass extends TestCase
 {
-    // @var string Twilio SendGrid API Key
+    /** @var string Twilio SendGrid API Key */
     protected static $apiKey;
-    // @var SendGrid Twilio SendGrid client
+    /** @var SendGrid Twilio SendGrid client */
     protected static $sg;
 
     /**
      * This method is run before the classes are initialised
-     * 
+     *
      * @return null
      */
     public static function setUpBeforeClass()
     {
         self::$apiKey = "SENDGRID_API_KEY";
         $host = ['host' => 'http://localhost:4010'];
-        self::$sg = new \SendGrid(self::$apiKey, $host);
+        self::$sg = new SendGrid(self::$apiKey, $host);
     }
 
     /**
-     * Compares to JSON objects and returns True if equal, 
+     * Compares to JSON objects and returns True if equal,
      * else return array of differences
-     * 
+     *
      * @param string $json1 A string representation of a JSON object
      * @param string $json2 A string representation of a JSON object
-     * 
+     *
      * @return bool|array
+     * @throws Exception
      */
     public static function compareJSONObjects($json1, $json2)
     {

--- a/test/integration/Alerts/AlertsTest.php
+++ b/test/integration/Alerts/AlertsTest.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Integration\Alerts;
+
+use SendGrid\Tests\BaseTestClass;
 
 class AlertsTest extends BaseTestClass
 {

--- a/test/integration/ApiKeys/ApiKeysTest.php
+++ b/test/integration/ApiKeys/ApiKeysTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SendGrid\Tests\ApiKeys;
+namespace SendGrid\Tests\Integration\ApiKeys;
 
 use SendGrid\Tests\BaseTestClass;
 

--- a/test/integration/Asm/AsmGroupsTest.php
+++ b/test/integration/Asm/AsmGroupsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SendGrid\Tests\Asm;
+namespace SendGrid\Tests\Integration\Asm;
 
 use SendGrid\Tests\BaseTestClass;
 

--- a/test/integration/Asm/AsmSuppressionTest.php
+++ b/test/integration/Asm/AsmSuppressionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SendGrid\Tests\Asm;
+namespace SendGrid\Tests\Integration\Asm;
 
 use SendGrid\Tests\BaseTestClass;
 

--- a/test/integration/Campaigns/CampaignsTest.php
+++ b/test/integration/Campaigns/CampaignsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SendGrid\Tests\Campaigns;
+namespace SendGrid\Tests\Integration\Campaigns;
 
 use SendGrid\Tests\BaseTestClass;
 

--- a/test/integration/Categories/CategoriesTest.php
+++ b/test/integration/Categories/CategoriesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SendGrid\Tests\Categories;
+namespace SendGrid\Tests\Integration\Categories;
 
 use SendGrid\Tests\BaseTestClass;
 

--- a/test/integration/Contacts/ContactDbTest.php
+++ b/test/integration/Contacts/ContactDbTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SendGrid\Tests\Contacts;
+namespace SendGrid\Tests\Integration\Contacts;
 
 use SendGrid\Tests\BaseTestClass;
 

--- a/test/integration/Helpers/Contacts/RecipientsTest.php
+++ b/test/integration/Helpers/Contacts/RecipientsTest.php
@@ -1,11 +1,11 @@
 <?php
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Integration\Helpers\Contacts;
 
 use SendGrid\Tests\BaseTestClass;
 use SendGrid\Contacts\RecipientForm;
 use SendGrid\Contacts\Recipient;
 
-class RecipientsTestRecipient extends BaseTestClass
+class RecipientsTest extends BaseTestClass
 {
     public function testRecipientsForm()
     {

--- a/test/integration/Helpers/Stats/StatsTest.php
+++ b/test/integration/Helpers/Stats/StatsTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Integration\Helpers\Stats;
 
 use SendGrid\Tests\BaseTestClass;
 use SendGrid\Stats\Stats;
@@ -47,7 +47,7 @@ class StatsTest extends BaseTestClass
      * @param array $expectedSum
      * @param array $expectedSubuserMonthly
      * @dataProvider invalidValues
-     * @expectedException Exception
+     * @expectedException \Exception
      */
     public function testGetValuesFail(
         $expectedGlobal,

--- a/test/integration/Ip/IpPoolsTest.php
+++ b/test/integration/Ip/IpPoolsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SendGrid\Tests\Ip;
+namespace SendGrid\Tests\Integration\Ip;
 
 use SendGrid\Tests\BaseTestClass;
 

--- a/test/integration/Ip/IpsTest.php
+++ b/test/integration/Ip/IpsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SendGrid\Tests\Ip;
+namespace SendGrid\Tests\Integration\Ip;
 
 use SendGrid\Tests\BaseTestClass;
 

--- a/test/integration/Ip/IpsWarmupTest.php
+++ b/test/integration/Ip/IpsWarmupTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SendGrid\Tests\Ip;
+namespace SendGrid\Tests\Integration\Ip;
 
 use SendGrid\Tests\BaseTestClass;
 

--- a/test/integration/Mail/MailBatchTest.php
+++ b/test/integration/Mail/MailBatchTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SendGrid\Tests\Mail;
+namespace SendGrid\Tests\Integration\Mail;
 
 use SendGrid\Tests\BaseTestClass;
 

--- a/test/integration/Mail/MailSendTest.php
+++ b/test/integration/Mail/MailSendTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SendGrid\Tests\Mail;
+namespace SendGrid\Tests\Integration\Mail;
 
 use SendGrid\Tests\BaseTestClass;
 

--- a/test/integration/Mail/MailSettingsTest.php
+++ b/test/integration/Mail/MailSettingsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SendGrid\Tests\Mail;
+namespace SendGrid\Tests\Integration\Mail;
 
 use SendGrid\Tests\BaseTestClass;
 

--- a/test/integration/Mail/MailboxProvidersTest.php
+++ b/test/integration/Mail/MailboxProvidersTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SendGrid\Tests\Mail;
+namespace SendGrid\Tests\Integration\Mail;
 
 use SendGrid\Tests\BaseTestClass;
 

--- a/test/integration/Scopes/ScopesTest.php
+++ b/test/integration/Scopes/ScopesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SendGrid\Tests\Scopes;
+namespace SendGrid\Tests\Integration\Scopes;
 
 use SendGrid\Tests\BaseTestClass;
 

--- a/test/integration/SenderAuthentication/DomainAuthenticationTest.php
+++ b/test/integration/SenderAuthentication/DomainAuthenticationTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace SendGrid\Tests\Whitelabel;
+namespace SendGrid\Tests\Integration\SenderAuthentication;
 
 use SendGrid\Tests\BaseTestClass;
 
-class WhitelabelDomainsTest extends BaseTestClass
+class DomainAuthenticationTest extends BaseTestClass
 {
     public function testWhitelabelDomainsPostMethod()
     {

--- a/test/integration/SenderAuthentication/LinkBrandingTest.php
+++ b/test/integration/SenderAuthentication/LinkBrandingTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace SendGrid\Tests\Whitelabel;
+namespace SendGrid\Tests\Integration\SenderAuthentication;
 
 use SendGrid\Tests\BaseTestClass;
 
-class WhitelabelLinksTest extends BaseTestClass
+class LinkBrandingTest extends BaseTestClass
 {
     public function testWhitelabelLinksPostMethod()
     {

--- a/test/integration/SenderAuthentication/ReverseDNSTest.php
+++ b/test/integration/SenderAuthentication/ReverseDNSTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace SendGrid\Tests\Whitelabel;
+namespace SendGrid\Tests\Integration\SenderAuthentication;
 
 use SendGrid\Tests\BaseTestClass;
 
-class WhitelabelIpsTest extends BaseTestClass
+class ReverseDNSTest extends BaseTestClass
 {
     public function testWhitelabelIpsPostMethod()
     {

--- a/test/integration/Senders/SendersTest.php
+++ b/test/integration/Senders/SendersTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SendGrid\Tests\Senders;
+namespace SendGrid\Tests\Integration\Senders;
 
 use SendGrid\Tests\BaseTestClass;
 

--- a/test/integration/Settings/AccessSettingsTest.php
+++ b/test/integration/Settings/AccessSettingsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SendGrid\Tests\Settings;
+namespace SendGrid\Tests\Integration\Settings;
 
 use SendGrid\Tests\BaseTestClass;
 

--- a/test/integration/Settings/PartnerSettingsTest.php
+++ b/test/integration/Settings/PartnerSettingsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SendGrid\Tests\Settings;
+namespace SendGrid\Tests\Integration\Settings;
 
 use SendGrid\Tests\BaseTestClass;
 

--- a/test/integration/Settings/TrackingSettingsTest.php
+++ b/test/integration/Settings/TrackingSettingsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SendGrid\Tests\Settings;
+namespace SendGrid\Tests\Integration\Settings;
 
 use SendGrid\Tests\BaseTestClass;
 

--- a/test/integration/Stats/BrowserStatsTest.php
+++ b/test/integration/Stats/BrowserStatsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SendGrid\Tests\Stats;
+namespace SendGrid\Tests\Integration\Stats;
 
 use SendGrid\Tests\BaseTestClass;
 

--- a/test/integration/Stats/ClientsStatsTest.php
+++ b/test/integration/Stats/ClientsStatsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SendGrid\Tests\Stats;
+namespace SendGrid\Tests\Integration\Stats;
 
 use SendGrid\Tests\BaseTestClass;
 

--- a/test/integration/Stats/DevicesStatsTest.php
+++ b/test/integration/Stats/DevicesStatsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SendGrid\Tests\Stats;
+namespace SendGrid\Tests\Integration\Stats;
 
 use SendGrid\Tests\BaseTestClass;
 

--- a/test/integration/Stats/GeoStatsTest.php
+++ b/test/integration/Stats/GeoStatsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SendGrid\Tests\Stats;
+namespace SendGrid\Tests\Integration\Stats;
 
 use SendGrid\Tests\BaseTestClass;
 

--- a/test/integration/Stats/StatsTest.php
+++ b/test/integration/Stats/StatsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SendGrid\Tests\Stats;
+namespace SendGrid\Tests\Integration\Stats;
 
 use SendGrid\Tests\BaseTestClass;
 

--- a/test/integration/Subusers/SubUsersTest.php
+++ b/test/integration/Subusers/SubUsersTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SendGrid\Tests\Subusers;
+namespace SendGrid\Tests\Integration\Subusers;
 
 use SendGrid\Tests\BaseTestClass;
 

--- a/test/integration/Suppression/SuppressionBlocksTest.php
+++ b/test/integration/Suppression/SuppressionBlocksTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SendGrid\Tests\Suppression;
+namespace SendGrid\Tests\Integration\Suppression;
 
 use SendGrid\Tests\BaseTestClass;
 

--- a/test/integration/Suppression/SuppressionBouncesTest.php
+++ b/test/integration/Suppression/SuppressionBouncesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SendGrid\Tests\Suppression;
+namespace SendGrid\Tests\Integration\Suppression;
 
 use SendGrid\Tests\BaseTestClass;
 

--- a/test/integration/Suppression/SuppressionInvalidEmailsTest.php
+++ b/test/integration/Suppression/SuppressionInvalidEmailsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SendGrid\Tests\Suppression;
+namespace SendGrid\Tests\Integration\Suppression;
 
 use SendGrid\Tests\BaseTestClass;
 

--- a/test/integration/Suppression/SuppressionSpamReportsTest.php
+++ b/test/integration/Suppression/SuppressionSpamReportsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SendGrid\Tests\Suppression;
+namespace SendGrid\Tests\Integration\Suppression;
 
 use SendGrid\Tests\BaseTestClass;
 

--- a/test/integration/Suppression/SuppressionUnsubscribesTest.php
+++ b/test/integration/Suppression/SuppressionUnsubscribesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SendGrid\Tests\Suppression;
+namespace SendGrid\Tests\Integration\Suppression;
 
 use SendGrid\Tests\BaseTestClass;
 

--- a/test/integration/Templates/TemplatesTest.php
+++ b/test/integration/Templates/TemplatesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SendGrid\Tests\Templates;
+namespace SendGrid\Tests\Integration\Templates;
 
 use SendGrid\Tests\BaseTestClass;
 

--- a/test/integration/Users/UserTest.php
+++ b/test/integration/Users/UserTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SendGrid\Tests\Users;
+namespace SendGrid\Tests\Integration\Users;
 
 use SendGrid\Tests\BaseTestClass;
 

--- a/test/unit/AttachmentsTest.php
+++ b/test/unit/AttachmentsTest.php
@@ -4,14 +4,14 @@
  *
  * PHP Version - 5.6, 7.0, 7.1, 7.2
  *
- * @package   SendGrid\Tests
+ * @package   SendGrid\Tests\Unit
  * @author    Elmer Thomas <dx@sendgrid.com>
  * @copyright 2018-19 Twilio SendGrid
  * @license   https://opensource.org/licenses/MIT The MIT License
  * @version   GIT: <git_id>
  * @link      http://packagist.org/packages/sendgrid/sendgrid
  */
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use SendGrid\Mail\Attachment;
@@ -19,9 +19,9 @@ use SendGrid\Mail\Attachment;
 /**
  * This file tests attachments.
  *
- * @package SendGrid\Tests
+ * @package SendGrid\Tests\Unit
  */
-class AttachmentsTests extends TestCase
+class AttachmentsTest extends TestCase
 {
     public function testWillEncodeNonBase64String() {
 

--- a/test/unit/DynamicTemplateTest.php
+++ b/test/unit/DynamicTemplateTest.php
@@ -4,7 +4,7 @@
  *
  * PHP Version - 5.6, 7.0, 7.1, 7.2
  *
- * @package   SendGrid\Tests
+ * @package   SendGrid\Tests\Unit
  * @author    Elmer Thomas <dx@sendgrid.com>
  * @copyright 2018-19 Twilio SendGrid
  * @license   https://opensource.org/licenses/MIT The MIT License
@@ -12,14 +12,16 @@
  * @link      http://packagist.org/packages/sendgrid/sendgrid
  */
 
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Unit;
+
+use SendGrid\Tests\BaseTestClass;
 
 // Test each use case that uses substitutions
 
 /**
  * This class tests the dynamic/transactional template functionality for a /mail/send API call
  *
- * @package SendGrid\Tests
+ * @package SendGrid\Tests\Unit
  */
 class DynamicTemplateTest extends BaseTestClass
 {
@@ -330,7 +332,7 @@ JSON;
         $json = json_encode($email->jsonSerialize());
         $isEqual = BaseTestClass::compareJSONObjects($json, $this->REQUEST_OBJECT);
         $this->assertTrue($isEqual);
-    }    
+    }
 
     /**
      * Test all parameters using objects

--- a/test/unit/FilesExistTest.php
+++ b/test/unit/FilesExistTest.php
@@ -4,7 +4,7 @@
  *
  * PHP Version - 5.6, 7.0, 7.1, 7.2
  *
- * @package   SendGrid\Tests
+ * @package   SendGrid\Tests\Unit
  * @author    Elmer Thomas <dx@sendgrid.com>
  * @copyright 2018-19 Twilio SendGrid
  * @license   https://opensource.org/licenses/MIT The MIT License
@@ -12,14 +12,14 @@
  * @link      http://packagist.org/packages/sendgrid/sendgrid
  */
 
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 
 /**
  * This class tests the existence of necessary files in this repo
  *
- * @package SendGrid\Tests
+ * @package SendGrid\Tests\Unit
  */
 class FilesExistTest extends TestCase
 {

--- a/test/unit/KitchenSinkTest.php
+++ b/test/unit/KitchenSinkTest.php
@@ -4,7 +4,7 @@
  *
  * PHP Version - 5.6, 7.0, 7.1, 7.2
  *
- * @package   SendGrid\Tests
+ * @package   SendGrid\Tests\Unit
  * @author    Elmer Thomas <dx@sendgrid.com>
  * @copyright 2018-19 Twilio SendGrid
  * @license   https://opensource.org/licenses/MIT The MIT License
@@ -12,12 +12,14 @@
  * @link      http://packagist.org/packages/sendgrid/sendgrid
  */
 
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Unit;
+
+use SendGrid\Tests\BaseTestClass;
 
 /**
  * This class tests the request object generation for a /mail/send API call
  *
- * @package SendGrid\Tests
+ * @package SendGrid\Tests\Unit
  */
 class KitchenSinkTest extends BaseTestClass
 {
@@ -33,7 +35,7 @@ class KitchenSinkTest extends BaseTestClass
       4
     ]
   },
-  "attachments": [ 
+  "attachments": [
     {
       "content": "YmFzZTY0IGVuY29kZWQgY29udGVudDE=",
       "content_id": "Banner",
@@ -237,7 +239,7 @@ JSON;
       4
     ]
   },
-  "attachments": [ 
+  "attachments": [
     {
       "content": "YmFzZTY0IGVuY29kZWQgY29udGVudDE=",
       "content_id": "Banner",

--- a/test/unit/MailGetContentsTest.php
+++ b/test/unit/MailGetContentsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use SendGrid\Mail\Mail;
@@ -11,7 +11,7 @@ use SendGrid\Mail\From;
 /**
  * This class tests the getContents() function in SendGrid\Mail\Mail
  *
- * @package SendGrid\Tests
+ * @package SendGrid\Tests\Unit
  */
 class MailGetContentsTest extends TestCase
 {

--- a/test/unit/MailHelperTest.php
+++ b/test/unit/MailHelperTest.php
@@ -4,7 +4,7 @@
  *
  * PHP Version - 5.6, 7.0, 7.1, 7.2
  *
- * @package   SendGrid\Tests
+ * @package   SendGrid\Tests\Unit
  * @author    Elmer Thomas <dx@sendgrid.com>
  * @copyright 2018-19 Twilio SendGrid
  * @license   https://opensource.org/licenses/MIT The MIT License
@@ -12,16 +12,17 @@
  * @link      http://packagist.org/packages/sendgrid/sendgrid
  */
 
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Unit;
 
+use PHPUnit\Framework\TestCase;
 use SendGrid\Mail\EmailAddress as EmailAddress;
 
 /**
  * This class tests email address encoding
  *
- * @package SendGrid\Tests
+ * @package SendGrid\Tests\Unit
  */
-class MailTest_Mail extends \PHPUnit\Framework\TestCase
+class MailHelperTest extends TestCase
 {
     /**
      * This method tests various types of unencoded emails

--- a/test/unit/MultipleEmailToMultipleRecipientsTest.php
+++ b/test/unit/MultipleEmailToMultipleRecipientsTest.php
@@ -4,7 +4,7 @@
  *
  * PHP Version - 5.6, 7.0, 7.1, 7.2
  *
- * @package   SendGrid\Tests
+ * @package   SendGrid\Tests\Unit
  * @author    Elmer Thomas <dx@sendgrid.com>
  * @copyright 2018-19 Twilio SendGrid
  * @license   https://opensource.org/licenses/MIT The MIT License
@@ -12,14 +12,16 @@
  * @link      http://packagist.org/packages/sendgrid/sendgrid
  */
 
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Unit;
+
+use SendGrid\Tests\BaseTestClass;
 
 /**
  * This class tests the request object generation for a /mail/send API call
  *
- * @package SendGrid\Tests
+ * @package SendGrid\Tests\Unit
  */
-class MultipleEmailToMulipleRecipientsTest extends BaseTestClass
+class MultipleEmailToMultipleRecipientsTest extends BaseTestClass
 {
 
     private $REQUEST_OBJECT = <<<'JSON'
@@ -276,7 +278,7 @@ JSON;
 
     /**
      * Test when we have individual subjects for each Personalization object
-     */ 
+     */
     public function testWithIndividualSubjects()
     {
         $from = new \SendGrid\Mail\From("test@example.com", "Example User");
@@ -333,7 +335,7 @@ JSON;
 
     /**
      * Test when we have individual subjects using dynamic templates for each Personalization object
-     */ 
+     */
     public function testWithIndividualSubjectsDynamicTemplates()
     {
         $from = new \SendGrid\Mail\From("test@example.com", "Example User");
@@ -393,7 +395,7 @@ JSON;
      * Test when we pass in an array of subjects
      *
      * @expectedException \SendGrid\Mail\TypeException
-     */ 
+     */
     public function testWithCollectionOfSubjects()
     {
         $from = new \SendGrid\Mail\From("test@example.com", "Example User");
@@ -455,7 +457,7 @@ JSON;
      * Test when we pass in an array of subjects
      *
      * @expectedException \SendGrid\Mail\TypeException
-     */ 
+     */
     public function testWithCollectionOfSubjectsDynamic()
     {
         $from = new \SendGrid\Mail\From("test@example.com", "Example User");

--- a/test/unit/SendGridTest.php
+++ b/test/unit/SendGridTest.php
@@ -4,7 +4,7 @@
  *
  * PHP Version - 5.6, 7.0, 7.1, 7.2
  *
- * @package   SendGrid\Tests
+ * @package   SendGrid\Tests\Unit
  * @author    Elmer Thomas <dx@sendgrid.com>
  * @copyright 2018-19 Twilio SendGrid
  * @license   https://opensource.org/licenses/MIT The MIT License
@@ -12,12 +12,15 @@
  * @link      http://packagist.org/packages/sendgrid/sendgrid
  */
 
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Unit;
+
+use SendGrid\Tests\BaseTestClass;
+
 
 /**
  * This class tests the Twilio SendGrid Client
  *
- * @package SendGrid\Tests
+ * @package SendGrid\Tests\Unit
  */
 class SendGridTest extends BaseTestClass
 {

--- a/test/unit/SingleEmailToASingleRecipientTest.php
+++ b/test/unit/SingleEmailToASingleRecipientTest.php
@@ -4,7 +4,7 @@
  *
  * PHP Version - 5.6, 7.0, 7.1, 7.2
  *
- * @package   SendGrid\Tests
+ * @package   SendGrid\Tests\Unit
  * @author    Elmer Thomas <dx@sendgrid.com>
  * @copyright 2018-19 Twilio SendGrid
  * @license   https://opensource.org/licenses/MIT The MIT License
@@ -12,12 +12,15 @@
  * @link      http://packagist.org/packages/sendgrid/sendgrid
  */
 
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Unit;
+
+use SendGrid\Tests\BaseTestClass;
+
 
 /**
  * This class tests the request object generation for a /mail/send API call
  *
- * @package SendGrid\Tests
+ * @package SendGrid\Tests\Unit
  */
 class SingleEmailToASingleRecipientTest extends BaseTestClass
 {

--- a/test/unit/SingleEmailToMultipleRecipientsTest.php
+++ b/test/unit/SingleEmailToMultipleRecipientsTest.php
@@ -4,7 +4,7 @@
  *
  * PHP Version - 5.6, 7.0, 7.1, 7.2
  *
- * @package   SendGrid\Tests
+ * @package   SendGrid\Tests\Unit
  * @author    Elmer Thomas <dx@sendgrid.com>
  * @copyright 2018-19 Twilio SendGrid
  * @license   https://opensource.org/licenses/MIT The MIT License
@@ -12,15 +12,17 @@
  * @link      http://packagist.org/packages/sendgrid/sendgrid
  */
 
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Unit;
+
+use SendGrid\Tests\BaseTestClass;
 
 
 /**
  * This class tests the request object generation for a /mail/send API call
  *
- * @package SendGrid\Tests
+ * @package SendGrid\Tests\Unit
  */
-class SingleEmailToMulipleRecipientsTest extends BaseTestClass
+class SingleEmailToMultipleRecipientsTest extends BaseTestClass
 {
 
     private $REQUEST_OBJECT = <<<'JSON'


### PR DESCRIPTION
Deprecation Notices caused by unneeded 'SendGrid\\' psr-4 autoload
Deprecation Notices caused by /test subdirectories: same namespace in different directories
Remaining Deprecation Notices by invalid class names
(Executed PHPUnit tests using Prism, but ignored results due to unknown status of working SendGrid API functions or test results caused by older PHPUnit version)

<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.

**All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
Fixes #906 

### Checklist
- [X] I acknowledge that all my contributions will be made under the project's license
- [X] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [ ] I have read the [Contribution Guide] and my PR follows them.
- [ ] I updated my branch with the development branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified

### Short description of what this PR does:
- Composer.json: Removed unneeded PSR-4 autoload entry to load the 'lib/' directory.
- Adjusted namespace of files in 'test/' to comply with PSR-4 class loading
- Renamed some test files which contains different class name

If you have questions, please send an email to [Twilio Sendgrid](mailto:dx@sendgrid.com), or file a Github Issue in this repository.
