### PR TITLE
docs: correct params order in example.php

### DIFF
--- a/examples/helpers/mail/example.php
+++ b/examples/helpers/mail/example.php
@@ -37,9 +37,9 @@ use SendGrid\Mail\ReplyTo;
 function helloEmail()
 {
     try {
-        $from = new From(null, "test@example.com");
+        $from = new From("test@example.com");
         $subject = "Hello World from the Twilio SendGrid PHP Library";
-        $to = new To(null, "test@example.com");
+        $to = new To("test@example.com");
         $content = new Content("text/plain", "some text here");
         $mail = new Mail($from, $to, $subject, $content);
 


### PR DESCRIPTION
# Fixes #

Fixed an example code in example.php which had a wrong params order. Both `From` and `To` extend from `EmailAddress` where `$emailAddress` is the first param (name second and optional)

https://github.com/sendgrid/sendgrid-php/blob/a8468b65dc4a9f1eff25936df79dd587177f4338/lib/mail/EmailAddress.php#L47-L51

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the master branch
- [ ] N/A I have added tests that prove my fix is effective or that my feature works
- [ ] N/A I have added necessary documentation about the functionality in the appropriate .md file
- [ ] N/A I have added inline documentation to the code I modified
