### PR TITLE
fix: Rename 'BaseInterface' to 'BaseSendGridClientInterface.php'

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
       "SendGrid\\Stats\\": "lib/stats/"
     },
     "classmap": [
-      "lib/BaseInterface.php",
+      "lib/BaseSendGridClientInterface.php",
       "lib/SendGrid.php",
       "lib/TwilioEmail.php"
     ]

--- a/lib/BaseSendGridClientInterface.php
+++ b/lib/BaseSendGridClientInterface.php
@@ -5,7 +5,7 @@
  *
  * @package SendGrid\Mail
  */
-class BaseInterface
+class BaseSendGridClientInterface
 {
     const VERSION = '7.5.1';
 

--- a/lib/SendGrid.php
+++ b/lib/SendGrid.php
@@ -6,7 +6,7 @@
  *
  * @package SendGrid\Mail
  */
-class SendGrid extends BaseInterface
+class SendGrid extends BaseSendGridClientInterface
 {
     /**
      * Set up the HTTP Client.

--- a/lib/TwilioEmail.php
+++ b/lib/TwilioEmail.php
@@ -6,7 +6,7 @@
  *
  * @package SendGrid\Mail
  */
-class TwilioEmail extends BaseInterface
+class TwilioEmail extends BaseSendGridClientInterface
 {
     /**
      * Set up the HTTP Client.

--- a/lib/loader.php
+++ b/lib/loader.php
@@ -2,7 +2,7 @@
 /**
  * Allows us to include one file instead of two when working without composer.
  */
-require_once __DIR__ . '/BaseInterface.php';
+require_once __DIR__ . '/BaseSendGridClientInterface.php';
 require_once __DIR__ . '/SendGrid.php';
 require_once __DIR__ . '/TwilioEmail.php';
 require_once __DIR__ . '/contacts/Recipient.php';


### PR DESCRIPTION
Fixes #964

Using such a common class name in a global namespace may cause collisions with other projects.