### PR TITLE
fix: support 'to' addresses with subjects

### DIFF
--- a/lib/mail/EmailAddress.php
+++ b/lib/mail/EmailAddress.php
@@ -186,6 +186,17 @@ class EmailAddress implements \JsonSerializable
     }
 
     /**
+     * Determine if this EmailAddress object is personalized by either
+     * containing substitutions or a specific subject.
+     *
+     * @return bool
+     */
+    public function isPersonalized()
+    {
+        return $this->getSubstitutions() || $this->getSubject();
+    }
+
+    /**
      * Return an array representing an EmailAddress object for the Twilio SendGrid API
      *
      * @return null|array

--- a/lib/mail/Mail.php
+++ b/lib/mail/Mail.php
@@ -105,7 +105,7 @@ class Mail implements \JsonSerializable
             $this->setFrom($from);
         }
         if (isset($to)) {
-            if (!is_array($to)) {
+            if (!\is_array($to)) {
                 $to = [$to];
             }
             $subjectCount = 0;
@@ -118,12 +118,12 @@ class Mail implements \JsonSerializable
                     $personalization = \end($this->personalization);
                 }
 
-                if (is_array($subject) && $subjectCount < \count($subject)) {
+                if (\is_array($subject) && $subjectCount < \count($subject)) {
                     $personalization->setSubject($subject[$subjectCount]);
                     $subjectCount++;
                 }
 
-                if (is_array($globalSubstitutions)) {
+                if (\is_array($globalSubstitutions)) {
                     foreach ($globalSubstitutions as $key => $value) {
                         if ($value instanceof Substitution) {
                             $personalization->addSubstitution($value);
@@ -134,7 +134,7 @@ class Mail implements \JsonSerializable
                 }
             }
         }
-        if (isset($subject) && !is_array($subject)) {
+        if (isset($subject) && !\is_array($subject)) {
             $this->setSubject($subject);
         }
         if (isset($plainTextContent)) {
@@ -221,7 +221,7 @@ class Mail implements \JsonSerializable
     ) {
         $emailFunctionCall = 'add' . $emailType;
 
-        if (current($emails) instanceof EmailAddress) {
+        if (\current($emails) instanceof EmailAddress) {
             foreach ($emails as $email) {
                 $this->$emailFunctionCall(
                     $email,
@@ -345,7 +345,7 @@ class Mail implements \JsonSerializable
      */
     public function getPersonalizationCount()
     {
-        return isset($this->personalization) ? count($this->personalization) : 0;
+        return isset($this->personalization) ? \count($this->personalization) : 0;
     }
 
     /**
@@ -626,7 +626,7 @@ class Mail implements \JsonSerializable
         $personalizationIndex = null,
         $personalization = null
     ) {
-        if (current($headers) instanceof Header) {
+        if (\current($headers) instanceof Header) {
             foreach ($headers as $header) {
                 $this->addHeader($header);
             }
@@ -761,7 +761,7 @@ class Mail implements \JsonSerializable
         $personalizationIndex = null,
         $personalization = null
     ) {
-        if (current($substitutions) instanceof Substitution) {
+        if (\current($substitutions) instanceof Substitution) {
             foreach ($substitutions as $substitution) {
                 $this->addSubstitution($substitution);
             }
@@ -842,7 +842,7 @@ class Mail implements \JsonSerializable
         $personalizationIndex = null,
         $personalization = null
     ) {
-        if (current($custom_args) instanceof CustomArg) {
+        if (\current($custom_args) instanceof CustomArg) {
             foreach ($custom_args as $custom_arg) {
                 $this->addCustomArg($custom_arg);
             }
@@ -1030,7 +1030,7 @@ class Mail implements \JsonSerializable
      */
     public function addContents($contents)
     {
-        if (current($contents) instanceof Content) {
+        if (\current($contents) instanceof Content) {
             foreach ($contents as $content) {
                 $this->addContent($content);
             }
@@ -1091,7 +1091,7 @@ class Mail implements \JsonSerializable
         $disposition = null,
         $content_id = null
     ) {
-        if (is_array($attachment)) {
+        if (\is_array($attachment)) {
             $attachment = new Attachment(
                 $attachment[0],
                 $attachment[1],
@@ -1185,7 +1185,7 @@ class Mail implements \JsonSerializable
      */
     public function addSections($sections)
     {
-        if (current($sections) instanceof Section) {
+        if (\current($sections) instanceof Section) {
             foreach ($sections as $section) {
                 $this->addSection($section);
             }
@@ -1236,7 +1236,7 @@ class Mail implements \JsonSerializable
      */
     public function addGlobalHeaders($headers)
     {
-        if (current($headers) instanceof Header) {
+        if (\current($headers) instanceof Header) {
             foreach ($headers as $header) {
                 $this->addGlobalHeader($header);
             }
@@ -1287,7 +1287,7 @@ class Mail implements \JsonSerializable
      */
     public function addGlobalSubstitutions($substitutions)
     {
-        if (current($substitutions) instanceof Substitution) {
+        if (\current($substitutions) instanceof Substitution) {
             foreach ($substitutions as $substitution) {
                 $this->addGlobalSubstitution($substitution);
             }
@@ -1384,7 +1384,7 @@ class Mail implements \JsonSerializable
      */
     public function addGlobalCustomArgs($custom_args)
     {
-        if (current($custom_args) instanceof CustomArg) {
+        if (\current($custom_args) instanceof CustomArg) {
             foreach ($custom_args as $custom_arg) {
                 $this->addGlobalCustomArg($custom_arg);
             }

--- a/lib/stats/Stats.php
+++ b/lib/stats/Stats.php
@@ -245,7 +245,7 @@ class Stats
      */
     protected function validateNumericArray($name, $value)
     {
-        if (!is_array($value) || empty($value) || !$this->isNumeric($value)) {
+        if (!\is_array($value) || empty($value) || !$this->isNumeric($value)) {
             throw new Exception($name . ' must be a non-empty numeric array.');
         }
     }
@@ -259,6 +259,6 @@ class Stats
      */
     protected function isNumeric(array $array)
     {
-        return array_keys($array) === range(0, count($array) - 1);
+        return \array_keys($array) === range(0, \count($array) - 1);
     }
 }

--- a/test/unit/MultipleEmailToMultipleRecipientsTest.php
+++ b/test/unit/MultipleEmailToMultipleRecipientsTest.php
@@ -5,6 +5,12 @@
 
 namespace SendGrid\Tests\Unit;
 
+use SendGrid\Mail\From;
+use SendGrid\Mail\HtmlContent;
+use SendGrid\Mail\Mail;
+use SendGrid\Mail\PlainTextContent;
+use SendGrid\Mail\Subject;
+use SendGrid\Mail\To;
 use SendGrid\Tests\BaseTestClass;
 
 /**
@@ -272,9 +278,9 @@ JSON;
      */
     public function testWithIndividualSubjects()
     {
-        $from = new \SendGrid\Mail\From("test@example.com", "Example User");
+        $from = new From("test@example.com", "Example User");
         $tos = [
-            new \SendGrid\Mail\To(
+            new To(
                 "test+test1@example.com",
                 "Example User1",
                 [
@@ -283,7 +289,7 @@ JSON;
                 ],
                 "Subject 1 -name-"
             ),
-            new \SendGrid\Mail\To(
+            new To(
                 "test+test2@example.com",
                 "Example User2",
                 [
@@ -292,7 +298,7 @@ JSON;
                 ],
                 "Subject 2 -name-"
             ),
-            new \SendGrid\Mail\To(
+            new To(
                 "test+test3@example.com",
                 "Example User3",
                 [
@@ -301,17 +307,17 @@ JSON;
                 ]
             )
         ];
-        $subject = new \SendGrid\Mail\Subject("Hi -name-!"); // default subject
+        $subject = new Subject("Hi -name-!"); // default subject
         $globalSubstitutions = [
             '-time-' => "2018-05-03 23:10:29"
         ];
-        $plainTextContent = new \SendGrid\Mail\PlainTextContent(
+        $plainTextContent = new PlainTextContent(
             "Hello -name-, your github is -github- sent at -time-"
         );
-        $htmlContent = new \SendGrid\Mail\HtmlContent(
+        $htmlContent = new HtmlContent(
             "<strong>Hello -name-, your github is <a href=\"-github-\">here</a></strong> sent at -time-"
         );
-        $email = new \SendGrid\Mail\Mail(
+        $email = new Mail(
             $from,
             $tos,
             $subject, // or array of subjects, these take precedence
@@ -321,7 +327,7 @@ JSON;
         );
         $json = json_encode($email->jsonSerialize());
         $isEqual = BaseTestClass::compareJSONObjects($json, $this->REQUEST_OBJECT);
-        $this->assertTrue($isEqual);
+        self::assertTrue($isEqual);
     }
 
     /**
@@ -329,9 +335,9 @@ JSON;
      */
     public function testWithIndividualSubjectsDynamicTemplates()
     {
-        $from = new \SendGrid\Mail\From("test@example.com", "Example User");
+        $from = new From("test@example.com", "Example User");
         $tos = [
-            new \SendGrid\Mail\To(
+            new To(
                 "test+test1@example.com",
                 "Example User1",
                 [
@@ -340,7 +346,7 @@ JSON;
                 ],
                 "Subject 1 -name-"
             ),
-            new \SendGrid\Mail\To(
+            new To(
                 "test+test2@example.com",
                 "Example User2",
                 [
@@ -349,7 +355,7 @@ JSON;
                 ],
                 "Subject 2 -name-"
             ),
-            new \SendGrid\Mail\To(
+            new To(
                 "test+test3@example.com",
                 "Example User3",
                 [
@@ -358,17 +364,17 @@ JSON;
                 ]
             )
         ];
-        $subject = new \SendGrid\Mail\Subject("Hi -name-!"); // default subject
+        $subject = new Subject("Hi -name-!"); // default subject
         $globalSubstitutions = [
             '-time-' => "2018-05-03 23:10:29"
         ];
-        $plainTextContent = new \SendGrid\Mail\PlainTextContent(
+        $plainTextContent = new PlainTextContent(
             "Hello -name-, your github is -github- sent at -time-"
         );
-        $htmlContent = new \SendGrid\Mail\HtmlContent(
+        $htmlContent = new HtmlContent(
             "<strong>Hello -name-, your github is <a href=\"-github-\">here</a></strong> sent at -time-"
         );
-        $email = new \SendGrid\Mail\Mail(
+        $email = new Mail(
             $from,
             $tos,
             $subject, // or array of subjects, these take precedence
@@ -379,7 +385,7 @@ JSON;
         $email->setTemplateId("d-13b8f94f-bcae-4ec6-b752-70d6cb59f932");
         $json = json_encode($email->jsonSerialize());
         $isEqual = BaseTestClass::compareJSONObjects($json, $this->REQUEST_OBJECT_3);
-        $this->assertTrue($isEqual);
+        self::assertTrue($isEqual);
     }
 
     /**
@@ -387,9 +393,9 @@ JSON;
      */
     public function testWithCollectionOfSubjects()
     {
-        $from = new \SendGrid\Mail\From("test@example.com", "Example User");
+        $from = new From("test@example.com", "Example User");
         $tos = [
-            new \SendGrid\Mail\To(
+            new To(
                 "test+test1@example.com",
                 "Example User1",
                 [
@@ -398,7 +404,7 @@ JSON;
                 ],
                 "Example User1 -name-"
             ),
-            new \SendGrid\Mail\To(
+            new To(
                 "test+test2@example.com",
                 "Example User2",
                 [
@@ -407,7 +413,7 @@ JSON;
                 ],
                 "Example User2 -name-"
             ),
-            new \SendGrid\Mail\To(
+            new To(
                 "test+test3@example.com",
                 "Example User3",
                 [
@@ -423,13 +429,13 @@ JSON;
         $globalSubstitutions = [
             '-time-' => "2018-05-03 23:10:29"
         ];
-        $plainTextContent = new \SendGrid\Mail\PlainTextContent(
+        $plainTextContent = new PlainTextContent(
             "Hello -name-, your github is -github- sent at -time-"
         );
-        $htmlContent = new \SendGrid\Mail\HtmlContent(
+        $htmlContent = new HtmlContent(
             "<strong>Hello -name-, your github is <a href=\"-github-\">here</a></strong> sent at -time-"
         );
-        $email = new \SendGrid\Mail\Mail(
+        $email = new Mail(
             $from,
             $tos,
             $subject, // or array of subjects, these take precedence
@@ -439,7 +445,7 @@ JSON;
         );
         $json = json_encode($email->jsonSerialize());
         $isEqual = BaseTestClass::compareJSONObjects($json, $this->REQUEST_OBJECT_2);
-        $this->assertTrue($isEqual);
+        self::assertTrue($isEqual);
     }
 
     /**
@@ -447,9 +453,9 @@ JSON;
      */
     public function testWithCollectionOfSubjectsDynamic()
     {
-        $from = new \SendGrid\Mail\From("test@example.com", "Example User");
+        $from = new From("test@example.com", "Example User");
         $tos = [
-            new \SendGrid\Mail\To(
+            new To(
                 "test+test1@example.com",
                 "Example User1",
                 [
@@ -458,7 +464,7 @@ JSON;
                 ],
                 "Example User1 -name-"
             ),
-            new \SendGrid\Mail\To(
+            new To(
                 "test+test2@example.com",
                 "Example User2",
                 [
@@ -467,7 +473,7 @@ JSON;
                 ],
                 "Example User2 -name-"
             ),
-            new \SendGrid\Mail\To(
+            new To(
                 "test+test3@example.com",
                 "Example User3",
                 [
@@ -483,13 +489,13 @@ JSON;
         $globalSubstitutions = [
             '-time-' => "2018-05-03 23:10:29"
         ];
-        $plainTextContent = new \SendGrid\Mail\PlainTextContent(
+        $plainTextContent = new PlainTextContent(
             "Hello -name-, your github is -github- sent at -time-"
         );
-        $htmlContent = new \SendGrid\Mail\HtmlContent(
+        $htmlContent = new HtmlContent(
             "<strong>Hello -name-, your github is <a href=\"-github-\">here</a></strong> sent at -time-"
         );
-        $email = new \SendGrid\Mail\Mail(
+        $email = new Mail(
             $from,
             $tos,
             $subject, // or array of subjects, these take precedence
@@ -500,6 +506,54 @@ JSON;
         $email->setTemplateId("d-13b8f94f-bcae-4ec6-b752-70d6cb59f932");
         $json = json_encode($email->jsonSerialize());
         $isEqual = BaseTestClass::compareJSONObjects($json, $this->REQUEST_OBJECT_4);
-        $this->assertTrue($isEqual);
+        self::assertTrue($isEqual);
+    }
+
+    public function testAddTosWithSubjects()
+    {
+        $expectedPayload = <<<'JSON'
+{
+  "personalizations": [
+    {
+      "subject": "Example User1 -name-",
+      "to": [
+        {
+          "email": "test+test1@example.com",
+          "name": "Example User1"
+        }
+      ]
+    },
+    {
+      "subject": "Example User2 -name-",
+      "to": [
+        {
+          "email": "test+test2@example.com",
+          "name": "Example User2"
+        }
+      ]
+    }
+  ]
+}
+JSON;
+
+        $tos = [
+            new To(
+                "test+test1@example.com",
+                "Example User1",
+                null,
+                "Example User1 -name-"
+            ),
+            new To(
+                "test+test2@example.com",
+                "Example User2",
+                null,
+                "Example User2 -name-"
+            )
+        ];
+        $email = new Mail();
+        $email->addTos($tos);
+        $json = json_encode($email->jsonSerialize());
+        $isEqual = BaseTestClass::compareJSONObjects($json, $expectedPayload);
+        self::assertTrue($isEqual);
     }
 }


### PR DESCRIPTION
If a specific 'to' address is "personalized" (contains substitutions or a subject), it should be in a new personalization object since a single personalization object cannot contain mixed substitutions or subjects.

Fixes #998 