### PR TITLE
fix: don't wrap names in double-quotes

### DIFF
--- a/lib/mail/EmailAddress.php
+++ b/lib/mail/EmailAddress.php
@@ -102,27 +102,6 @@ class EmailAddress implements \JsonSerializable
     {
         Assert::string($name, 'name');
 
-        /*
-            Issue #368
-            ==========
-            If the name is not wrapped in double quotes and contains a comma or
-            semicolon, the API fails to parse it correctly.
-            When wrapped in double quotes, commas, semicolons and unescaped single
-            quotes are supported.
-            Escaped double quotes are supported as well but will appear unescaped in
-            the mail (e.g. "O\'Keefe").
-            Double quotes will be shown in some email clients, so the name should
-            only be wrapped when necessary.
-        */
-        // Only wrap in double quote if comma or semicolon are found
-        if (false !== strpos($name, ',') || false !== strpos($name, ';')) {
-            // Unescape quotes
-            $name = stripslashes(html_entity_decode($name, ENT_QUOTES));
-            // Escape only double quotes
-            $name = str_replace('"', '\\"', $name);
-            // Wrap in double quotes
-            $name = '"' . $name . '"';
-        }
         $this->name = (!empty($name)) ? $name : null;
     }
 

--- a/test/unit/EmailAddressTest.php
+++ b/test/unit/EmailAddressTest.php
@@ -50,34 +50,6 @@ class EmailAddressTest extends TestCase
         $this->email->setName('');
         $json = json_encode($this->email->jsonSerialize());
         self::assertEquals('null', $json);
-
-        $this->email->setName('Doe, John');
-        $json = json_encode($this->email->jsonSerialize());
-        self::assertEquals(
-            '{"name":"\\"Doe, John\\""}',
-            $json
-        );
-
-        $this->email->setName('Doe; John');
-        $json = json_encode($this->email->jsonSerialize());
-        self::assertEquals(
-            '{"name":"\\"Doe; John\\""}',
-            $json
-        );
-
-        $this->email->setName('John "Billy" O\'Keeffe');
-        $json = json_encode($this->email->jsonSerialize());
-        self::assertEquals(
-            '{"name":"John \\"Billy\\" O\'Keeffe"}',
-            $json
-        );
-
-        $this->email->setName('O\'Keeffe, John "Billy"');
-        $json = json_encode($this->email->jsonSerialize());
-        self::assertEquals(
-            '{"name":"\\"O\'Keeffe, John \\\\\\"Billy\\\\\\"\\""}',
-            $json
-        );
     }
 
     /**
@@ -714,14 +686,6 @@ JSON;
         $emailAddress->setName('Elmer');
 
         $this->assertSame('Elmer', $emailAddress->getName());
-    }
-
-    public function testSetNameOnCommaChar()
-    {
-        $emailAddress = new EmailAddress();
-        $emailAddress->setName('Chun-Sheng, Li');
-
-        $this->assertSame('"Chun-Sheng, Li"', $emailAddress->getName());
     }
 
     /**


### PR DESCRIPTION
The backend has been updated (reference _MP-4337_) to properly handling names with special characters so the original "fix" is no longer needed.

Reverts https://github.com/sendgrid/sendgrid-php/pull/511

Fixes #897