### PR TITLE
docs: Incorrect value order in example array for addAttachments

### DIFF
--- a/USE_CASES.md
+++ b/USE_CASES.md
@@ -399,15 +399,15 @@ $email->addAttachment(
 $attachments = [
     [
         "base64 encoded content2",
-        "banner2.jpeg",
         "image/jpeg",
+        "banner2.jpeg",
         "attachment",
         "Banner 3"
     ],
     [
         "base64 encoded content3",
-        "banner3.gif",
         "image/gif",
+        "banner3.gif",
         "inline",
         "Banner 3"
     ]


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

# Fixes #

The file type and file name are in the wrong order for the $attachments array used in addAttachments. Used that way, files do not attach properly.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified