### PR TITLE
fix: Fixing namespace for classes on test/unit folder

### DIFF
--- a/test/unit/AsmTest.php
+++ b/test/unit/AsmTest.php
@@ -2,7 +2,7 @@
 /**
  * This file tests Asm.
  */
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use SendGrid\Mail\Asm;

--- a/test/unit/BatchIdTest.php
+++ b/test/unit/BatchIdTest.php
@@ -2,7 +2,7 @@
 /**
  * This file tests BatchId.
  */
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use SendGrid\Mail\BatchId;

--- a/test/unit/BccSettingsTest.php
+++ b/test/unit/BccSettingsTest.php
@@ -2,7 +2,7 @@
 /**
  * This file tests BccSettings.
  */
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use SendGrid\Mail\BccSettings;

--- a/test/unit/BypassListManagementTest.php
+++ b/test/unit/BypassListManagementTest.php
@@ -2,7 +2,7 @@
 /**
  * This file tests BypassListManagement.
  */
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use SendGrid\Mail\BypassListManagement;

--- a/test/unit/CategoryTest.php
+++ b/test/unit/CategoryTest.php
@@ -2,7 +2,7 @@
 /**
  * This file tests Category.
  */
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use SendGrid\Mail\Category;

--- a/test/unit/ClickTrackingTest.php
+++ b/test/unit/ClickTrackingTest.php
@@ -2,7 +2,7 @@
 /**
  * This file tests ClickTracking.
  */
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use SendGrid\Mail\ClickTracking;

--- a/test/unit/ContentTest.php
+++ b/test/unit/ContentTest.php
@@ -2,7 +2,7 @@
 /**
  * This file tests Content.
  */
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use SendGrid\Mail\Content;

--- a/test/unit/CustomArgTest.php
+++ b/test/unit/CustomArgTest.php
@@ -2,7 +2,7 @@
 /**
  * This file tests CustomArg.
  */
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use SendGrid\Mail\CustomArg;

--- a/test/unit/FooterTest.php
+++ b/test/unit/FooterTest.php
@@ -2,7 +2,7 @@
 /**
  * This file tests Footer.
  */
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use SendGrid\Mail\Footer;

--- a/test/unit/GanalyticsTest.php
+++ b/test/unit/GanalyticsTest.php
@@ -2,7 +2,7 @@
 /**
  * This file tests Ganalytics.
  */
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use SendGrid\Mail\Ganalytics;

--- a/test/unit/GroupIdTest.php
+++ b/test/unit/GroupIdTest.php
@@ -2,7 +2,7 @@
 /**
  * This file tests GroupId.
  */
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use SendGrid\Mail\GroupId;

--- a/test/unit/HeaderTest.php
+++ b/test/unit/HeaderTest.php
@@ -2,7 +2,7 @@
 /**
  * This file tests Header.
  */
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use SendGrid\Mail\Header;

--- a/test/unit/HtmlContentTest.php
+++ b/test/unit/HtmlContentTest.php
@@ -2,7 +2,7 @@
 /**
  * This file tests HtmlContent.
  */
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use SendGrid\Mail\HtmlContent;

--- a/test/unit/IpPoolNameTest.php
+++ b/test/unit/IpPoolNameTest.php
@@ -2,7 +2,7 @@
 /**
  * This file tests IpPoolName.
  */
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use SendGrid\Mail\IpPoolName;

--- a/test/unit/MailTest.php
+++ b/test/unit/MailTest.php
@@ -3,7 +3,7 @@
  * This file tests Mail.
  */
 
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Unit;
 
 use SendGrid\Mail\Mail;
 use SendGrid\Mail\Personalization;

--- a/test/unit/OpenTrackingTest.php
+++ b/test/unit/OpenTrackingTest.php
@@ -3,7 +3,7 @@
  * This file tests OpenTracking.
  */
 
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Unit;
 
 use SendGrid\Mail\OpenTracking;
 use PHPUnit\Framework\TestCase;

--- a/test/unit/PersonalizationTest.php
+++ b/test/unit/PersonalizationTest.php
@@ -3,7 +3,7 @@
  * This file tests Personalization.
  */
 
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Unit;
 
 use SendGrid\Mail\Personalization;
 use SendGrid\Mail\To;

--- a/test/unit/PlainTextContentTest.php
+++ b/test/unit/PlainTextContentTest.php
@@ -3,7 +3,7 @@
  * This file tests PlainTextContent.
  */
 
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Unit;
 
 use SendGrid\Mail\PlainTextContent;
 use PHPUnit\Framework\TestCase;

--- a/test/unit/SandBoxModeTest.php
+++ b/test/unit/SandBoxModeTest.php
@@ -3,7 +3,7 @@
  * This file tests SandBoxMode.
  */
 
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Unit;
 
 use SendGrid\Mail\SandBoxMode;
 use PHPUnit\Framework\TestCase;

--- a/test/unit/SectionTest.php
+++ b/test/unit/SectionTest.php
@@ -3,7 +3,7 @@
  * This file tests Section.
  */
 
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Unit;
 
 use SendGrid\Mail\Section;
 use PHPUnit\Framework\TestCase;

--- a/test/unit/SendAtTest.php
+++ b/test/unit/SendAtTest.php
@@ -3,7 +3,7 @@
  * This file tests SendAt.
  */
 
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Unit;
 
 use SendGrid\Mail\SendAt;
 use PHPUnit\Framework\TestCase;

--- a/test/unit/SpamCheckTest.php
+++ b/test/unit/SpamCheckTest.php
@@ -3,7 +3,7 @@
  * This file tests SpamCheck.
  */
 
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Unit;
 
 use SendGrid\Mail\SpamCheck;
 use PHPUnit\Framework\TestCase;

--- a/test/unit/SubjectTest.php
+++ b/test/unit/SubjectTest.php
@@ -3,7 +3,7 @@
  * This file tests Subject.
  */
 
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Unit;
 
 use SendGrid\Mail\Subject;
 use PHPUnit\Framework\TestCase;

--- a/test/unit/SubscriptionTrackingTest.php
+++ b/test/unit/SubscriptionTrackingTest.php
@@ -3,7 +3,7 @@
  * This file tests SubscriptionTracking.
  */
 
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Unit;
 
 use SendGrid\Mail\SubscriptionTracking;
 use PHPUnit\Framework\TestCase;

--- a/test/unit/TemplateIdTest.php
+++ b/test/unit/TemplateIdTest.php
@@ -3,7 +3,7 @@
  * This file tests TemplateId.
  */
 
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Unit;
 
 use SendGrid\Mail\TemplateId;
 use PHPUnit\Framework\TestCase;

--- a/test/unit/TrackingSettingsTest.php
+++ b/test/unit/TrackingSettingsTest.php
@@ -3,7 +3,7 @@
  * This file tests TrackingSettings.
  */
 
-namespace SendGrid\Tests;
+namespace SendGrid\Tests\Unit;
 
 use SendGrid\Mail\TrackingSettings;
 use SendGrid\Mail\ClickTracking;


### PR DESCRIPTION
# Fixes #

Fixing some classes namespaces and they should be `SendGrid\Tests\Unit` namespace.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [X] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [X] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-php/blob/main/CONTRIBUTING.md) and my PR follows them
- [X] I have titled the PR appropriately
- [X] I have updated my branch with the main branch
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added the necessary documentation about the functionality in the appropriate .md file
- [X] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://support.sendgrid.com), or create a GitHub Issue in this repository.
