### PR TITLE
Suppress deprecation warnings in PHP 8.1

### DIFF
--- a/lib/contacts/Recipient.php
+++ b/lib/contacts/Recipient.php
@@ -67,6 +67,7 @@ class Recipient implements \JsonSerializable
      *
      * @return null|array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return array_filter(

--- a/lib/mail/Asm.php
+++ b/lib/mail/Asm.php
@@ -127,6 +127,7 @@ class Asm implements \JsonSerializable
      *
      * @return null|array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return array_filter(

--- a/lib/mail/Attachment.php
+++ b/lib/mail/Attachment.php
@@ -207,6 +207,7 @@ class Attachment implements \JsonSerializable
      *
      * @return null|array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return array_filter(

--- a/lib/mail/BatchId.php
+++ b/lib/mail/BatchId.php
@@ -61,6 +61,7 @@ class BatchId implements \JsonSerializable
      *
      * @return null|string
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->getBatchId();

--- a/lib/mail/BccSettings.php
+++ b/lib/mail/BccSettings.php
@@ -91,6 +91,7 @@ class BccSettings implements \JsonSerializable
      *
      * @return null|array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return array_filter(

--- a/lib/mail/BypassBounceManagement.php
+++ b/lib/mail/BypassBounceManagement.php
@@ -67,6 +67,7 @@ class BypassBounceManagement implements \JsonSerializable
      *
      * @return null|array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return array_filter(

--- a/lib/mail/BypassListManagement.php
+++ b/lib/mail/BypassListManagement.php
@@ -66,6 +66,7 @@ class BypassListManagement implements \JsonSerializable
      *
      * @return null|array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return array_filter(

--- a/lib/mail/BypassSpamManagement.php
+++ b/lib/mail/BypassSpamManagement.php
@@ -67,6 +67,7 @@ class BypassSpamManagement implements \JsonSerializable
      *
      * @return null|array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return array_filter(

--- a/lib/mail/BypassUnsubscribeManagement.php
+++ b/lib/mail/BypassUnsubscribeManagement.php
@@ -68,6 +68,7 @@ class BypassUnsubscribeManagement implements \JsonSerializable
      *
      * @return null|array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return array_filter(

--- a/lib/mail/Category.php
+++ b/lib/mail/Category.php
@@ -63,6 +63,7 @@ class Category implements \JsonSerializable
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->getCategory();

--- a/lib/mail/ClickTracking.php
+++ b/lib/mail/ClickTracking.php
@@ -91,6 +91,7 @@ class ClickTracking implements \JsonSerializable
      *
      * @return null|array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return array_filter(

--- a/lib/mail/Content.php
+++ b/lib/mail/Content.php
@@ -103,6 +103,7 @@ class Content implements \JsonSerializable
      *
      * @return null|array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return array_filter(

--- a/lib/mail/CustomArg.php
+++ b/lib/mail/CustomArg.php
@@ -96,6 +96,7 @@ class CustomArg implements \JsonSerializable
      *
      * @return null|array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return array_filter(

--- a/lib/mail/EmailAddress.php
+++ b/lib/mail/EmailAddress.php
@@ -180,6 +180,7 @@ class EmailAddress implements \JsonSerializable
      *
      * @return null|array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return array_filter(

--- a/lib/mail/Footer.php
+++ b/lib/mail/Footer.php
@@ -119,6 +119,7 @@ class Footer implements \JsonSerializable
      *
      * @return null|array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return array_filter(

--- a/lib/mail/Ganalytics.php
+++ b/lib/mail/Ganalytics.php
@@ -219,6 +219,7 @@ class Ganalytics implements \JsonSerializable
      *
      * @return null|array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return array_filter(

--- a/lib/mail/GroupId.php
+++ b/lib/mail/GroupId.php
@@ -59,6 +59,7 @@ class GroupId implements \JsonSerializable
      *
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->getGroupId();

--- a/lib/mail/GroupsToDisplay.php
+++ b/lib/mail/GroupsToDisplay.php
@@ -95,6 +95,7 @@ class GroupsToDisplay implements \JsonSerializable
      *
      * @return null|array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->getGroupsToDisplay();

--- a/lib/mail/Header.php
+++ b/lib/mail/Header.php
@@ -93,6 +93,7 @@ class Header implements \JsonSerializable
      *
      * @return null|array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return array_filter(

--- a/lib/mail/IpPoolName.php
+++ b/lib/mail/IpPoolName.php
@@ -68,6 +68,7 @@ class IpPoolName implements \JsonSerializable
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->getIpPoolName();

--- a/lib/mail/Mail.php
+++ b/lib/mail/Mail.php
@@ -1951,6 +1951,7 @@ class Mail implements \JsonSerializable
      * @return null|array
      * @throws TypeException
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         // Detect if we are using the new dynamic templates

--- a/lib/mail/MailSettings.php
+++ b/lib/mail/MailSettings.php
@@ -376,6 +376,7 @@ class MailSettings implements \JsonSerializable
      *
      * @return null|array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return array_filter(

--- a/lib/mail/OpenTracking.php
+++ b/lib/mail/OpenTracking.php
@@ -105,6 +105,7 @@ class OpenTracking implements \JsonSerializable
      *
      * @return null|array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return array_filter(

--- a/lib/mail/Personalization.php
+++ b/lib/mail/Personalization.php
@@ -299,6 +299,7 @@ class Personalization implements \JsonSerializable
      *
      * @return null|array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         if ($this->getHasDynamicTemplate()) {

--- a/lib/mail/SandBoxMode.php
+++ b/lib/mail/SandBoxMode.php
@@ -61,6 +61,7 @@ class SandBoxMode implements \JsonSerializable
      *
      * @return null|array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return array_filter(

--- a/lib/mail/Section.php
+++ b/lib/mail/Section.php
@@ -92,6 +92,7 @@ class Section implements \JsonSerializable
      *
      * @return null|array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return array_filter(

--- a/lib/mail/SendAt.php
+++ b/lib/mail/SendAt.php
@@ -87,6 +87,7 @@ class SendAt implements \JsonSerializable
      *
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->getSendAt();

--- a/lib/mail/SpamCheck.php
+++ b/lib/mail/SpamCheck.php
@@ -139,6 +139,7 @@ class SpamCheck implements \JsonSerializable
      *
      * @return null|array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return array_filter(

--- a/lib/mail/Subject.php
+++ b/lib/mail/Subject.php
@@ -60,6 +60,7 @@ class Subject implements \JsonSerializable
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->getSubject();

--- a/lib/mail/SubscriptionTracking.php
+++ b/lib/mail/SubscriptionTracking.php
@@ -199,6 +199,7 @@ class SubscriptionTracking implements \JsonSerializable
      *
      * @return null|array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return array_filter(

--- a/lib/mail/Substitution.php
+++ b/lib/mail/Substitution.php
@@ -102,6 +102,7 @@ class Substitution implements \JsonSerializable
      *
      * @return null|array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return array_filter(

--- a/lib/mail/TemplateId.php
+++ b/lib/mail/TemplateId.php
@@ -71,6 +71,7 @@ class TemplateId implements \JsonSerializable
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->getTemplateId();

--- a/lib/mail/TrackingSettings.php
+++ b/lib/mail/TrackingSettings.php
@@ -231,6 +231,7 @@ class TrackingSettings implements \JsonSerializable
      *
      * @return null|array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return array_filter(


### PR DESCRIPTION
In PHP 8.1, we need to add the mixed return type to the jsonSerialize implementation. The mixed return type is not supported in older versions. It is possible to suppress the deprecation warning by adding a PHP attribute. Older PHP versions will interpret attributes as a comment.