### PR TITLE
docs: rewrite function description

### DIFF
--- a/lib/mail/Mail.php
+++ b/lib/mail/Mail.php
@@ -1756,8 +1756,7 @@ class Mail implements \JsonSerializable
     /**
      * Disable sandbox mode on a MailSettings object
      *
-     * This allows you to send a test email to ensure that your request
-     * body is valid and formatted correctly.
+     * This to ensure that your request is not in sandbox mode.
      *
      * @throws TypeException
      */


### PR DESCRIPTION
I found that the function description did not match the way it works.
It's a small contribution but houses always built with a small bricks