### PR TITLE
fix: preserve substitutions from To in Personalization

### DIFF
--- a/lib/mail/Personalization.php
+++ b/lib/mail/Personalization.php
@@ -43,11 +43,19 @@ class Personalization implements \JsonSerializable
 
     /**
      * Add a To object to a Personalization object
+     * If there are substitutions in the To object preserve them 
+     * by transfering them to the Personalization object
      *
      * @param To $email To object
      */
     public function addTo($email)
     {
+        if ($subs = $email->getSubstitutions()) {
+            foreach ($subs as $key => $value) {
+                $this->addSubstitution($key, $value);
+            }
+        }
+        
         $this->tos[] = $email;
     }
 


### PR DESCRIPTION
If there are substitutions in the To object preserve them by transfering them to the Personalization object.

Currently this does not work (we loose all substitutions from the To):
```php
$personalization0 = new Personalization();
$personalization0->addTo(new To(
        "test+test2@example.com",
        "Example User2",
        [
            '-name-' => 'Example User 2'   // <--this is lost and not sent to sendgrid API
        ],
        "Example User2 -name-"
));
$email->addPersonalization($personalization0);
```
We can either add the substitution during `addTo` method (as current PR is proposing) or parse all Tos during `getSubstitutions` method and add them to the `substitution` property. I propose the first way because it is similar to what we have in https://github.com/sendgrid/sendgrid-php/blob/main/lib/mail/Mail.php#L205

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [ ] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-php/blob/main/CONTRIBUTING.md) and my PR follows them
- [ ] I have titled the PR appropriately
- [ ] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified


