### PR TITLE
docs: improve signed webhook event payload encoding

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -142,3 +142,4 @@ If you are still having trouble getting the validation to work, follow the follo
 - Be sure to use the *raw* payload for validation
 - Be sure to include a trailing carriage return and newline in your payload
 - In case of multi-event webhooks, make sure you include the trailing newline and carriage return after *each* event
+- In case of not using the *raw* payload, make sure you encode the json with `JSON_UNESCAPED_SLASHES` flag


### PR DESCRIPTION
If the payload contains slashed and if you encode the data manually, then the default `json_encode` function escapes the slashes which causes the verification to fail.

In my case, I decoded the payload with `json_decode` and then encoded it before the verification. However, the payload contained the user agent data, which has slashes, and the `json_encode` function was escaping the slashes, causing the verification to fail. So, I encoded the data like `json_encode($payload, JSON_UNESCAPED_SLASHES)` with the flag, and it started to verify successfully.