### PR TITLE
fix: implicit nullable parameter warning on PHP 8.4

### DIFF
--- a/lib/mail/Mail.php
+++ b/lib/mail/Mail.php
@@ -101,7 +101,7 @@ class Mail implements \JsonSerializable
         $subject = null,
         $plainTextContent = null,
         $htmlContent = null,
-        array $globalSubstitutions = null
+        ?array $globalSubstitutions = null
     ) {
         if (!isset($from)
             && !isset($to)


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test, misc.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

# Fixes #

Implicit nullable parameters are deprecated on PHP 8.4.

Resolved by explicitly marking the parameter as nullable. I checked for other instances of this error, but couldn't find any.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-php/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://support.sendgrid.com).
